### PR TITLE
Implements updates to triple store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+solr-home/1.5/data

--- a/xforms/admin.xhtml
+++ b/xforms/admin.xhtml
@@ -676,7 +676,15 @@
       </xforms:submission>
 
       <!-- ************************* EXIST SUBMISSIONS FOR POSTING TO TRIPLE STORE************************** -->
-      <xforms:submission id="post-to-3store" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/post-to-3store.xq" serialization="none" method="get" replace="instance" instance="3store-xquery-result" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
+      <xforms:submission id="post-to-3store"
+			 resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/post-to-3store.xq?recordId={instance('control-instance')/id}"
+			 ref="instance('control-instance')"
+			 instance="control-instance"
+			 replace="none"
+			 serialization="none"
+			 method="get"
+			 xxforms:username="{instance('exist-config')/username}"
+			 xxforms:password="{instance('exist-config')/password}">
 
         <xforms:action ev:event="xforms-submit-error">
           <xforms:setvalue ref="instance('control-instance')/status" value="event('response-body')" />
@@ -689,16 +697,44 @@
         </xforms:action>
       </xforms:submission>
 
+      <xforms:submission id="post-all-to-3store" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/post-to-3store.xq" serialization="none" method="get" replace="instance" instance="3store-xquery-result" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
+
+        <xforms:action ev:event="xforms-submit-error">
+          <xforms:setvalue ref="instance('control-instance')/status" value="event('response-body')" />
+          <xforms:message level="modal">Error posting all to 3store.</xforms:message>
+        </xforms:action>
+        <xforms:action ev:event="xforms-submit-done">
+          <xforms:action if="number(instance('xquery-result'))">
+            <xforms:setvalue ref="instance('control-instance')/status">Successfully posted to 3store.</xforms:setvalue>
+          </xforms:action>
+        </xforms:action>
+      </xforms:submission>
+
       <xforms:submission id="delete-all-from-3store" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/delete-from-3store.xq" serialization="none" method="get" replace="instance" instance="3store-xquery-result" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
-        <xforms:message ev:event="xforms-submit-error" level="modal">Error deleting from 3store.</xforms:message>
+        <xforms:message ev:event="xforms-submit-error" level="modal">Error deleting all from 3store.</xforms:message>
         <xforms:action ev:event="xforms-submit-done">
           <xforms:action if="number(instance('xquery-result'))">
             <xforms:setvalue ref="instance('control-instance')/status">Successfully deleted all from 3store.</xforms:setvalue>
           </xforms:action>
         </xforms:action>
-
       </xforms:submission>
 
+      <xforms:submission id="delete-object-from-3store"
+			 resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/delete-from-3store.xq?recordId={instance('control-instance')/id}"
+			 ref="instance('control-instance')"
+			 instance="control-instance"
+			 replace="none"
+			 serialization="none"
+			 method="get"
+			 xxforms:username="{instance('exist-config')/username}"
+			 xxforms:password="{instance('exist-config')/password}">
+        <xforms:message ev:event="xforms-submit-error" level="modal">Error deleting object from 3store.</xforms:message>
+        <xforms:action ev:event="xforms-submit-done">
+          <xforms:action if="number(instance('xquery-result'))">
+            <xforms:setvalue ref="instance('control-instance')/status">Successfully deleted object from 3store.</xforms:setvalue>
+          </xforms:action>
+        </xforms:action>
+      </xforms:submission>
 
       <!-- ************************* XFORMS-MODEL-CONSTRUCT-DONE ************************** -->
       <xforms:action ev:event="xforms-model-construct-done">
@@ -1277,6 +1313,8 @@
                                           <!-- update publicationStatus -->
                                           <xforms:setvalue ref="instance('control-instance')/publicationStatus">inProcess</xforms:setvalue>
                                           <xforms:send submission="load-object" />
+					  <!-- delete from 3store -->
+					  <xforms:send submission="delete-object-from-3store" />
                                           <!-- delete from Solr -->
                                           <xforms:setvalue ref="instance('deleteId')/query" value="concat('recordId:&#x022;', instance('control-instance')/id, '&#x022;')" />
                                           <xforms:send submission="delete-solr-doc" />
@@ -1293,6 +1331,8 @@
                                           <xforms:setvalue ref="instance('control-instance')/id" value="$id" />
                                           <xforms:setvalue ref="instance('control-instance')/publicationStatus">approved</xforms:setvalue>
                                           <xforms:send submission="load-object" />
+					  <!-- publish to 3store -->
+					  <xforms:send submission="post-to-3store" />
                                           <!-- publish to solr -->
                                           <xforms:send submission="nuds-to-solr" />
                                           <xforms:send submission="submit-commit" />
@@ -1378,7 +1418,7 @@
           <xforms:setvalue ref="instance('deleteId')/query" value="concat('recordId:&#x022;', instance('control-instance')/id, '&#x022;')" />
           <xforms:send submission="delete-solr-doc" />
 	  <!-- also delete from 3store TK -->
-
+	  <xforms:send submission="delete-object-from-3store" />
           <!-- get new numCount -->
           <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="instance('xqueries')/query[@id='collection-count']" />
           <xforms:send submission="xquery-collection" />
@@ -1401,7 +1441,7 @@
       <fr:positive-choice>
         <fr:label>Yes</fr:label>
         <xforms:action ev:event="DOMActivate">
-	  <xforms:send submission="post-to-3store" />
+	  <xforms:send submission="post-all-to-3store" />
           <xforms:var name="count" select="if (instance('config')/collection_type='hoard') then '25' else '100'" />
           <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='publish-all'], 'COUNT', $count)" />
           <xforms:send submission="xquery-collection" />
@@ -1431,7 +1471,7 @@
       <fr:positive-choice>
         <fr:label>Yes</fr:label>
         <xforms:action ev:event="DOMActivate">
-          <xforms:send submission="post-to-3store" />
+          <xforms:send submission="post-all-to-3store" />
         </xforms:action>
       </fr:positive-choice>
     </fr:alert-dialog>

--- a/xforms/admin.xhtml
+++ b/xforms/admin.xhtml
@@ -682,9 +682,16 @@
 
             <xforms:action ev:event="xforms-submit-error">
                 <xforms:setvalue ref="instance('control-instance')/status" value="event('response-body')" />
+                <xforms:message level="modal">
+                    Error posting to 3store.
+                </xforms:message>
+            </xforms:action>
+            <xforms:action ev:event="xforms-submit-done">
+                <xforms:action if="number(instance('xquery-result'))">
+                    <xforms:setvalue ref="instance('control-instance')/status">Successfully posted to 3store.</xforms:setvalue>
+                </xforms:action>
             </xforms:action>
         </xforms:submission>
-
         <!-- ************************* XFORMS-MODEL-CONSTRUCT-DONE ************************** -->
         <xforms:action ev:event="xforms-model-construct-done">
             <!-- load numishare config file on xforms construction -->

--- a/xforms/admin.xhtml
+++ b/xforms/admin.xhtml
@@ -701,6 +701,14 @@
 					ref="instance('pagination-result')//record[id=instance('control-instance')/id]/published" value="true()"/>
 			</xforms:submission>
 
+			<!-- ************************* EXIST SUBMISSIONS FOR POSTING TO TRIPLE STORE************************** -->
+			<xforms:submission id="post-to-3store" ref="instance('collections-list')"
+					   resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/post-to-3store.xq"
+					   method="get" replace="none"
+					   xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
+				<xforms:message ev:event="xforms-submit-error" level="modal">Error posting to 3store.</xforms:message>
+			</xforms:submission>
+
 			<!-- ************************* XFORMS-MODEL-CONSTRUCT-DONE ************************** -->
 			<xforms:action ev:event="xforms-model-construct-done">
 				<!-- load numishare config file on xforms construction -->
@@ -1065,6 +1073,12 @@
 										</ul>
 										<h2>Publication</h2>
 										<ul>
+										  <li>
+										    <xforms:trigger appearance="minimal">
+										      <xforms:label>Put them in 3store</xforms:label>
+										      <xforms:dispatch target="publish-3store-dialog" name="fr-show" ev:event="DOMActivate"/>
+										    </xforms:trigger>
+										  </li>
 											<li>
 												<xforms:trigger appearance="minimal">
 													<xforms:label>Publish All Approved Objects</xforms:label>
@@ -1436,6 +1450,18 @@
 				</xforms:action>
 			</fr:positive-choice>
 		</fr:alert-dialog>
+		<fr:alert-dialog id="publish-3store-dialog">
+			<fr:label>Publish to Fueski</fr:label>
+			<fr:message>Do you want to publish to 3store? This may take several minutes.</fr:message>
+			<fr:negative-choice>
+				<fr:label>No</fr:label>
+			</fr:negative-choice>
+			<fr:positive-choice>
+			  <fr:label>Yes</fr:label>
+			  <xforms:send submission="post-to-3store"/>
+			</fr:positive-choice>
+		</fr:alert-dialog>
+
 		<fr:alert-dialog id="unpublish-all">
 			<fr:label>Unpublish All</fr:label>
 			<fr:message>Do you want to unpublish all objects?</fr:message>

--- a/xforms/admin.xhtml
+++ b/xforms/admin.xhtml
@@ -447,6 +447,10 @@
             </xforms:bind>
         </xforms:bind>
 
+
+        <xforms:bind nodeset="instance('3store-xquery-result')" type="xxforms:xml" />
+
+
         <!-- **************** DYNAMIC VALIDATION CONTROLS ********************** -->
         <xforms:action ev:event="xxforms-invalid" ev:observer="collections-list">
             <xforms:setvalue ref="instance('control-instance')/create-collection-trigger" value="false()" />
@@ -678,14 +682,6 @@
 
             <xforms:action ev:event="xforms-submit-error">
                 <xforms:setvalue ref="instance('control-instance')/status" value="event('response-body')" />
-                <xforms:message level="modal">
-                    Error posting to 3store.
-                </xforms:message>
-            </xforms:action>
-            <xforms:action ev:event="xforms-submit-done">
-                <xforms:action if="number(instance('xquery-result'))">
-                    <xforms:setvalue ref="instance('control-instance')/status">Successfully posted to 3store.</xforms:setvalue>
-                </xforms:action>
             </xforms:action>
         </xforms:submission>
 

--- a/xforms/admin.xhtml
+++ b/xforms/admin.xhtml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:xxforms="http://orbeon.org/oxf/xml/xforms"
-    xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:fr="http://orbeon.org/oxf/xml/form-runner" xmlns:exist="http://exist.sourceforge.net/NS/exist" xmlns:xxi="http://orbeon.org/oxf/xml/xinclude" xmlns:numishare="https://github.comu/ewg118/numishare" xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:nuds="http://nomisma.org/nuds">
+      xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:fr="http://orbeon.org/oxf/xml/form-runner" xmlns:exist="http://exist.sourceforge.net/NS/exist" xmlns:xxi="http://orbeon.org/oxf/xml/xinclude" xmlns:numishare="https://github.comu/ewg118/numishare" xmlns:xlink="http://www.w3.org/1999/xlink"
+      xmlns:nuds="http://nomisma.org/nuds">
 
-<head>
+  <head>
     <title>Numishare: Administrative Interface</title>
     <!-- Core + Skin CSS -->
     <!--<link rel="stylesheet" href="/fr/style/bootstrap/css/bootstrap.css" type="text/css" />
-		<link rel="stylesheet" href="/fr/style/form-runner-bootstrap-override.css" type="text/css" />-->
+	<link rel="stylesheet" href="/fr/style/form-runner-bootstrap-override.css" type="text/css" />-->
     <link rel="shortcut icon" href="/ops/images/orbeon-icon-16.ico" />
     <link rel="icon" href="/ops/images/orbeon-icon-16.png" type="image/png" />
     <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
@@ -15,284 +15,284 @@
     <link rel="stylesheet" href="/apps/numishare/xforms/css/xforms.css" />
 
     <xforms:model xmlns="http://nomisma.org/nuds">
-        <!-- exist URL is stored in an XML file -->
-        <xforms:instance id="exist-config" xxforms:exclude-result-prefixes="#all">
-            <xi:include href="../exist-config.xml" />
-        </xforms:instance>
+      <!-- exist URL is stored in an XML file -->
+      <xforms:instance id="exist-config" xxforms:exclude-result-prefixes="#all">
+        <xi:include href="../exist-config.xml" />
+      </xforms:instance>
 
-        <xforms:instance id="control-instance" xxforms:exclude-result-prefixes="#all">
-            <controls xmlns="">
-                <id/>
-                <identifiers/>
-                <publicationStatus/>
-                <collection-name/>
-                <status/>
-                <error/>
-                <numFound/>
-                <page>1</page>
-                <query_input/>
-                <query_sent/>
-                <interface/>
-                <create-collection-trigger>false</create-collection-trigger>
-                <username/>
-            </controls>
-        </xforms:instance>
+      <xforms:instance id="control-instance" xxforms:exclude-result-prefixes="#all">
+        <controls xmlns="">
+          <id/>
+          <identifiers/>
+          <publicationStatus/>
+          <collection-name/>
+          <status/>
+          <error/>
+          <numFound/>
+          <page>1</page>
+          <query_input/>
+          <query_sent/>
+          <interface/>
+          <create-collection-trigger>false</create-collection-trigger>
+          <username/>
+        </controls>
+      </xforms:instance>
 
-        <xforms:instance id="config" xxforms:exclude-result-prefixes="#all">
-            <config xmlns="" />
-        </xforms:instance>
+      <xforms:instance id="config" xxforms:exclude-result-prefixes="#all">
+        <config xmlns="" />
+      </xforms:instance>
 
-        <xforms:instance id="collections-list" xxforms:exclude-result-prefixes="#all">
-            <collections xmlns="" />
-        </xforms:instance>
+      <xforms:instance id="collections-list" xxforms:exclude-result-prefixes="#all">
+        <collections xmlns="" />
+      </xforms:instance>
 
-        <xforms:instance id="config-template" xxforms:exclude-result-prefixes="#all">
-            <config xmlns="" version="19.04">
-                <title>Numishare</title>
-                <description>A short description of the collection.</description>
-                <logo/>
-                <url>http://localhost:8080/orbeon/numishare/</url>
-                <server-port>8080</server-port>
-                <sparql_endpoint>http://nomisma.org/query</sparql_endpoint>
-                <annotation_sparql_endpoint/>
-                <type_series/>
-                <specimens_per_page>48</specimens_per_page>
-                <solr_published>http://localhost:8080/solr/numishare-published/</solr_published>
-                <geonames_api_key/>
-                <mapboxKey/>
-                <contact/>
-                <google_analytics/>
-                <collection_type>object</collection_type>
-                <features_enabled>true</features_enabled>
-                <pelagios_enabled>false</pelagios_enabled>
-                <ctype_enabled>false</ctype_enabled>
-                <index_subtype_metadata>false</index_subtype_metadata>
-                <union_type_catalog enabled="false">
-                    <series typeSeries="" uriSpace="" collectionName="" />
-                </union_type_catalog>
-                <uri_space/>
-                <baselayers>
-                    <layer enabled="true">mb_physical</layer>
-                    <layer enabled="true">osm</layer>
-                    <layer enabled="true">imperium</layer>
-                </baselayers>
-                <template>
-						<agencyName/>
-						<copyrightHolder/>
-						<collection/>
-						<language>en</language>
-						<rights>http://rightsstatements.org/vocab/NoC-US/1.0/</rights>
-						<license for="data">http://opendatacommons.org/licenses/odbl/</license>
-						<license for="images">https://creativecommons.org/choose/mark/</license>
-						<owner/>
-						<repository/>
-					</template>
-                <includes/>
-                <installation_path>/usr/local/projects/numishare</installation_path>
-                <images>
-                    <absolute_path>/usr/local/projects/numishare</absolute_path>
-                    <iiif_server/>
-                    <thumbnail>120</thumbnail>
-                    <reference>400</reference>
-                </images>
-                <languages>
-                    <language code="ar" enabled="false" />
-                    <language code="bg" enabled="false" />
-                    <language code="de" enabled="false" />
-                    <language code="el" enabled="false" />
-                    <language code="en" enabled="false" />
-                    <language code="es" enabled="false" />
-                    <language code="fr" enabled="false" />
-                    <language code="it" enabled="false" />
-                    <language code="nl" enabled="false" />
-                    <language code="pl" enabled="false" />
-                    <language code="ro" enabled="false" />
-                    <language code="ru" enabled="false" />
-                    <language code="sv" enabled="false" />
-                </languages>
-                <positions/>
-                <localTypes/>
-                <facets>
-                    <facet>artist_facet</facet>
-                    <facet>authority_facet</facet>
-                    <facet>citation_facet</facet>
-                    <facet>coinType_facet</facet>
-                    <facet>collection_facet</facet>
-                    <facet>degree_facet</facet>
-                    <facet>deity_facet</facet>
-                    <facet>denomination_facet</facet>
-                    <facet>department_facet</facet>
-                    <facet>engraver_facet</facet>
-                    <facet>era_facet</facet>
-                    <facet>findspot_facet</facet>
-                    <facet>issuer_facet</facet>
-                    <facet>maker_facet</facet>
-                    <facet>manufacture_facet</facet>
-                    <facet>material_facet</facet>
-                    <facet>mint_facet</facet>
-                    <facet>objectType_facet</facet>
-                    <facet>portrait_facet</facet>
-                    <facet>reference_facet</facet>
-                    <facet>region_facet</facet>
-                    <facet>script_facet</facet>
-                    <facet>state_facet</facet>
-                    <facet>subject_facet</facet>
-                </facets>
-                <hoard_options>
-                    <display_stub>authority,mint,date</display_stub>
-                </hoard_options>
-                <theme>
-                    <orbeon_theme>default</orbeon_theme>
-                    <themes_url>http://localhost:8080/orbeon/themes/</themes_url>
-                    <layouts>
-                        <results>
-                            <image_location>right</image_location>
-                        </results>
-                        <display>
-                            <nuds>
-                                <orientation>vertical</orientation>
-                                <image_location>left</image_location>
-                            </nuds>
-                        </display>
-                    </layouts>
-                </theme>
-                <footer>
-                    <div class="row">
-                        <div class="col-md-12">
-                            <p>Powered by <a href="https://github.com/ewg118/numishare" target="_blank">Numishare</a></p>
-                        </div>
-                    </div>
-                </footer>
-                <pages>
-                    <index>
-                        <p>
-                            <a href="https://github.com/ewg118/numishare/">Numishare</a> is a free, open source, modularized system of Tomcat applications for the web delivery of cultural heritage artifacts, with particular focus on coins and medals.
-                            Metadata are edited with XForms and delivered with <a href="http://www.orbeon.com">Orbeon</a>, <a href="http://exist-db.org/exist/apps/homepage/index.html">eXist-db</a>, and <a href="http://lucene.apache.org/solr/">Apache Solr</a>.</p>
-                    </index>
-                    <compare enabled="true" />
-                    <analyze enabled="false" />
-                    <visualize enabled="true" />
-                    <apis enabled="true" />
-                    <feedback enabled="false">
-                        <smtp-host>localhost</smtp-host>
-                        <to type="">
-                            <email></email>
-                            <name></name>
-                        </to>
-                        <recipient-types>
-                            <type>curatorial</type>
-                            <type>technical</type>
-                        </recipient-types>
-                        <feedback-types>
-                            <type type="curatorial">Cataloging error</type>
-                            <type type="curatorial|technical">Comment or suggestion</type>
-                            <type type="technical">Interface bug</type>
-                            <type type="curatorial">Other</type>
-                        </feedback-types>
-                    </feedback>
-                    <symbols enabled="false" />
-                    <identify enabled="false" />
-                </pages>
-                <navigation>
-                    <tab href="results" id="browse" />
-                    <tab href="search" id="search" />
-                    <tab href="maps" id="maps" />
-                    <tab href="symbols" id="symbols" />
-                    <tab href="identify" id="identify" label="Identify a Coin" />
-                    <tab href="contributors" id="contributors" />
-                    <tab href="compare" id="compare" />
-                    <tab href="analyze" id="analyze" />
-                    <tab href="visualize" id="visualize" />
-                    <tab href="feedback" id="feedback" />
-                    <tab href="apis" id="apis" label="APIs" />
-                    <tab id="pages" />
-                    <tab id="languages-tab" />
-                </navigation>
-            </config>
-        </xforms:instance>
-        <xforms:instance id="object" xxforms:exclude-result-prefixes="#all">
-            <nuds xmlns="" />
-        </xforms:instance>
+      <xforms:instance id="config-template" xxforms:exclude-result-prefixes="#all">
+        <config xmlns="" version="19.04">
+          <title>Numishare</title>
+          <description>A short description of the collection.</description>
+          <logo/>
+          <url>http://localhost:8080/orbeon/numishare/</url>
+          <server-port>8080</server-port>
+          <sparql_endpoint>http://nomisma.org/query</sparql_endpoint>
+          <annotation_sparql_endpoint/>
+          <type_series/>
+          <specimens_per_page>48</specimens_per_page>
+          <solr_published>http://localhost:8080/solr/numishare-published/</solr_published>
+          <geonames_api_key/>
+          <mapboxKey/>
+          <contact/>
+          <google_analytics/>
+          <collection_type>object</collection_type>
+          <features_enabled>true</features_enabled>
+          <pelagios_enabled>false</pelagios_enabled>
+          <ctype_enabled>false</ctype_enabled>
+          <index_subtype_metadata>false</index_subtype_metadata>
+          <union_type_catalog enabled="false">
+            <series typeSeries="" uriSpace="" collectionName="" />
+          </union_type_catalog>
+          <uri_space/>
+          <baselayers>
+            <layer enabled="true">mb_physical</layer>
+            <layer enabled="true">osm</layer>
+            <layer enabled="true">imperium</layer>
+          </baselayers>
+          <template>
+	    <agencyName/>
+	    <copyrightHolder/>
+	    <collection/>
+	    <language>en</language>
+	    <rights>http://rightsstatements.org/vocab/NoC-US/1.0/</rights>
+	    <license for="data">http://opendatacommons.org/licenses/odbl/</license>
+	    <license for="images">https://creativecommons.org/choose/mark/</license>
+	    <owner/>
+	    <repository/>
+	  </template>
+          <includes/>
+          <installation_path>/usr/local/projects/numishare</installation_path>
+          <images>
+            <absolute_path>/usr/local/projects/numishare</absolute_path>
+            <iiif_server/>
+            <thumbnail>120</thumbnail>
+            <reference>400</reference>
+          </images>
+          <languages>
+            <language code="ar" enabled="false" />
+            <language code="bg" enabled="false" />
+            <language code="de" enabled="false" />
+            <language code="el" enabled="false" />
+            <language code="en" enabled="false" />
+            <language code="es" enabled="false" />
+            <language code="fr" enabled="false" />
+            <language code="it" enabled="false" />
+            <language code="nl" enabled="false" />
+            <language code="pl" enabled="false" />
+            <language code="ro" enabled="false" />
+            <language code="ru" enabled="false" />
+            <language code="sv" enabled="false" />
+          </languages>
+          <positions/>
+          <localTypes/>
+          <facets>
+            <facet>artist_facet</facet>
+            <facet>authority_facet</facet>
+            <facet>citation_facet</facet>
+            <facet>coinType_facet</facet>
+            <facet>collection_facet</facet>
+            <facet>degree_facet</facet>
+            <facet>deity_facet</facet>
+            <facet>denomination_facet</facet>
+            <facet>department_facet</facet>
+            <facet>engraver_facet</facet>
+            <facet>era_facet</facet>
+            <facet>findspot_facet</facet>
+            <facet>issuer_facet</facet>
+            <facet>maker_facet</facet>
+            <facet>manufacture_facet</facet>
+            <facet>material_facet</facet>
+            <facet>mint_facet</facet>
+            <facet>objectType_facet</facet>
+            <facet>portrait_facet</facet>
+            <facet>reference_facet</facet>
+            <facet>region_facet</facet>
+            <facet>script_facet</facet>
+            <facet>state_facet</facet>
+            <facet>subject_facet</facet>
+          </facets>
+          <hoard_options>
+            <display_stub>authority,mint,date</display_stub>
+          </hoard_options>
+          <theme>
+            <orbeon_theme>default</orbeon_theme>
+            <themes_url>http://localhost:8080/orbeon/themes/</themes_url>
+            <layouts>
+              <results>
+                <image_location>right</image_location>
+              </results>
+              <display>
+                <nuds>
+                  <orientation>vertical</orientation>
+                  <image_location>left</image_location>
+                </nuds>
+              </display>
+            </layouts>
+          </theme>
+          <footer>
+            <div class="row">
+              <div class="col-md-12">
+                <p>Powered by <a href="https://github.com/ewg118/numishare" target="_blank">Numishare</a></p>
+              </div>
+            </div>
+          </footer>
+          <pages>
+            <index>
+              <p>
+                <a href="https://github.com/ewg118/numishare/">Numishare</a> is a free, open source, modularized system of Tomcat applications for the web delivery of cultural heritage artifacts, with particular focus on coins and medals.
+                Metadata are edited with XForms and delivered with <a href="http://www.orbeon.com">Orbeon</a>, <a href="http://exist-db.org/exist/apps/homepage/index.html">eXist-db</a>, and <a href="http://lucene.apache.org/solr/">Apache Solr</a>.</p>
+            </index>
+            <compare enabled="true" />
+            <analyze enabled="false" />
+            <visualize enabled="true" />
+            <apis enabled="true" />
+            <feedback enabled="false">
+              <smtp-host>localhost</smtp-host>
+              <to type="">
+                <email></email>
+                <name></name>
+              </to>
+              <recipient-types>
+                <type>curatorial</type>
+                <type>technical</type>
+              </recipient-types>
+              <feedback-types>
+                <type type="curatorial">Cataloging error</type>
+                <type type="curatorial|technical">Comment or suggestion</type>
+                <type type="technical">Interface bug</type>
+                <type type="curatorial">Other</type>
+              </feedback-types>
+            </feedback>
+            <symbols enabled="false" />
+            <identify enabled="false" />
+          </pages>
+          <navigation>
+            <tab href="results" id="browse" />
+            <tab href="search" id="search" />
+            <tab href="maps" id="maps" />
+            <tab href="symbols" id="symbols" />
+            <tab href="identify" id="identify" label="Identify a Coin" />
+            <tab href="contributors" id="contributors" />
+            <tab href="compare" id="compare" />
+            <tab href="analyze" id="analyze" />
+            <tab href="visualize" id="visualize" />
+            <tab href="feedback" id="feedback" />
+            <tab href="apis" id="apis" label="APIs" />
+            <tab id="pages" />
+            <tab id="languages-tab" />
+          </navigation>
+        </config>
+      </xforms:instance>
+      <xforms:instance id="object" xxforms:exclude-result-prefixes="#all">
+        <nuds xmlns="" />
+      </xforms:instance>
 
-        <xforms:instance id="languages">
-            <xi:include href="instances/languages.xml" />
-        </xforms:instance>
+      <xforms:instance id="languages">
+        <xi:include href="instances/languages.xml" />
+      </xforms:instance>
 
-        <xforms:instance id="license-list">
-            <xi:include href="instances/licenses.xml" />
-        </xforms:instance>
+      <xforms:instance id="license-list">
+        <xi:include href="instances/licenses.xml" />
+      </xforms:instance>
 
-        <xforms:instance id="rights-list">
-            <xi:include href="instances/rights.xml" />
-        </xforms:instance>
+      <xforms:instance id="rights-list">
+        <xi:include href="instances/rights.xml" />
+      </xforms:instance>
 
-        <xforms:instance id="request" xxforms:exclude-result-prefixes="#all">
-            <request/>
-        </xforms:instance>
+      <xforms:instance id="request" xxforms:exclude-result-prefixes="#all">
+        <request/>
+      </xforms:instance>
 
-        <!-- XQuery instances -->
-        <xforms:instance id="eXist-xquery" xxforms:exclude-result-prefixes="#all">
-            <exist:query xmlns="">
-                <exist:text/>
-            </exist:query>
-        </xforms:instance>
+      <!-- XQuery instances -->
+      <xforms:instance id="eXist-xquery" xxforms:exclude-result-prefixes="#all">
+        <exist:query xmlns="">
+          <exist:text/>
+        </exist:query>
+      </xforms:instance>
 
-        <xforms:instance id="xqueries">
-            <queries xmlns="">
-                <query id="collection-count">
-                    <![CDATA[xquery version "1.0"; <report>{count(collection())}</report>]]>
-                </query>
-                <query id="get-objects">
-                    <![CDATA[xquery version "1.0";
+      <xforms:instance id="xqueries">
+        <queries xmlns="">
+          <query id="collection-count">
+            <![CDATA[xquery version "1.0"; <report>{count(collection())}</report>]]>
+          </query>
+          <query id="get-objects">
+            <![CDATA[xquery version "1.0";
 						declare namespace nuds="http://nomisma.org/nuds";
 						declare namespace nh="http://nomisma.org/nudsHoard";
 						<report> { 
-							for $record in subsequence(collection(), START, 20)
-								let $type := $record/*/local-name()
-								return if ($type='nuds') then
-									<record>
-										<type>{ $type }</type>
-										<maintenanceStatus>{$record/nuds:nuds/nuds:control/nuds:maintenanceStatus/text()}</maintenanceStatus>
-										<publicationStatus>{data($record/nuds:nuds/nuds:control/nuds:publicationStatus)}</publicationStatus>
-										<recordType>{ string($record/nuds:nuds/@recordType) }</recordType>
-										<id>{$record//nuds:recordId/text()}</id>
-										<title>{ $record//nuds:descMeta/nuds:title[@xml:lang='en']/text() }</title>
-										<obverse> {concat($record//nuds:typeDesc/nuds:obverse/nuds:type/nuds:description[@xml:lang='en'], '/', $record//nuds:typeDesc/nuds:obverse/nuds:legend) } </obverse>
-										<reverse> {concat($record//nuds:typeDesc/nuds:reverse/nuds:type/nuds:description[@xml:lang='en'], '/', $record//nuds:typeDesc/nuds:reverse/nuds:legend) } </reverse>
-										<published>false</published>
-									</record>
-								else if ($type='nudsHoard') then 
-									<record>
-										<type>{ $type }</type>
-										<maintenanceStatus>{$record/nh:nudsHoard/nh:control/nh:maintenanceStatus/text()}</maintenanceStatus>
-										<publicationStatus>{data($record/nh:nuds/nh:control/nh:publicationStatus)}</publicationStatus>
-										<id>{ $record//nh:recordId/text() }</id>
-										<title>{$record//nh:descMeta/nh:title[@xml:lang='en']/text()}</title>
-										<published>false</published>
-									</record>
-								else <record/>
-							}
+						  for $record in subsequence(collection(), START, 20)
+						  let $type := $record/*/local-name()
+						  return if ($type='nuds') then
+						  <record>
+						    <type>{ $type }</type>
+						    <maintenanceStatus>{$record/nuds:nuds/nuds:control/nuds:maintenanceStatus/text()}</maintenanceStatus>
+						    <publicationStatus>{data($record/nuds:nuds/nuds:control/nuds:publicationStatus)}</publicationStatus>
+						    <recordType>{ string($record/nuds:nuds/@recordType) }</recordType>
+						    <id>{$record//nuds:recordId/text()}</id>
+						    <title>{ $record//nuds:descMeta/nuds:title[@xml:lang='en']/text() }</title>
+						    <obverse> {concat($record//nuds:typeDesc/nuds:obverse/nuds:type/nuds:description[@xml:lang='en'], '/', $record//nuds:typeDesc/nuds:obverse/nuds:legend) } </obverse>
+						    <reverse> {concat($record//nuds:typeDesc/nuds:reverse/nuds:type/nuds:description[@xml:lang='en'], '/', $record//nuds:typeDesc/nuds:reverse/nuds:legend) } </reverse>
+						    <published>false</published>
+						  </record>
+						  else if ($type='nudsHoard') then 
+						  <record>
+						    <type>{ $type }</type>
+						    <maintenanceStatus>{$record/nh:nudsHoard/nh:control/nh:maintenanceStatus/text()}</maintenanceStatus>
+						    <publicationStatus>{data($record/nh:nuds/nh:control/nh:publicationStatus)}</publicationStatus>
+						    <id>{ $record//nh:recordId/text() }</id>
+						    <title>{$record//nh:descMeta/nh:title[@xml:lang='en']/text()}</title>
+						    <published>false</published>
+						  </record>
+						  else <record/>
+						  }
 						</report>]]>
-                </query>
-                <query id="collection-metadata">
-                    <![CDATA[xquery version "1.0";
+          </query>
+          <query id="collection-metadata">
+            <![CDATA[xquery version "1.0";
 						let $sequence:= tokenize('%SEQUENCE%', ',')						
 						return
 						<metadata>
-							{
-							for $collection-name in $sequence
-							let $path:= concat('/db/', $collection-name, '/config.xml')
-							return 
-								<collection id="{$collection-name}">
-									<title>{data(doc($path)/config/title)}</title>
-									<description>{data(doc($path)/config/description)}</description>
-									<url>{data(doc($path)/config/url)}</url>
-								</collection>
-							}
+						  {
+						  for $collection-name in $sequence
+						  let $path:= concat('/db/', $collection-name, '/config.xml')
+						  return 
+						  <collection id="{$collection-name}">
+						    <title>{data(doc($path)/config/title)}</title>
+						    <description>{data(doc($path)/config/description)}</description>
+						    <url>{data(doc($path)/config/url)}</url>
+						  </collection>
+						  }
 						</metadata>]]>
-                </query>
-                <query id="create-collection">
-                    <![CDATA[xquery version "1.0";
+          </query>
+          <query id="create-collection">
+            <![CDATA[xquery version "1.0";
 							declare namespace xmldb="http://exist-db.org/xquery/xmldb";
 							let $collection := '/db/%COLLECTION%'
 							let $path := '%PATH%'
@@ -302,1154 +302,1187 @@
 							for $doc in xmldb:get-child-resources($collection)							
 							return sm:chmod(xs:anyURI(concat($collection, '/', $doc)), 'rwxrwxrwx')
 						]]>
-                </query>
-                <query id="delete-collection">
-                    <![CDATA[xquery version "1.0";
+          </query>
+          <query id="delete-collection">
+            <![CDATA[xquery version "1.0";
 							declare namespace xmldb="http://exist-db.org/xquery/xmldb";
 							let $collection := '/db/%COLLECTION%'
 							return
 								xmldb:remove($collection)
 						]]>
-                </query>
-                <query id="query-objects">
-                    <![CDATA[xquery version "1.0";
+          </query>
+          <query id="query-objects">
+            <![CDATA[xquery version "1.0";
 						declare namespace nuds="http://nomisma.org/nuds";
 						declare namespace nh="http://nomisma.org/nudsHoard";
 						<report> { 
-							for $record in collection()[contains(descendant::*[local-name()='recordId'], 'QUERY') or descendant::*[local-name()='title'] = 'QUERY'] let $type := $record/*/local-name()
-							return if ($type='nuds') then 
-							<record>
-								<type>{ $type }</type>
-								<maintenanceStatus>{$record/nuds:nuds/nuds:control/nuds:maintenanceStatus/text()}</maintenanceStatus>
-								<publicationStatus>{data($record/nuds:nuds/nuds:control/nuds:publicationStatus)}</publicationStatus>
-								<recordType>{ string($record/nuds:nuds/@recordType) }</recordType>
-								<id>{ $record//nuds:recordId/text() }</id>
-								<title>{$record//nuds:descMeta/nuds:title[@xml:lang='en']/text() }</title>
-								<obverse> { concat($record//nuds:typeDesc/nuds:obverse/nuds:type/nuds:description[@xml:lang='en'], '/', $record//nuds:typeDesc/nuds:obverse/nuds:legend) } </obverse>
-								<reverse> { concat($record//nuds:typeDesc/nuds:reverse/nuds:type/nuds:description[@xml:lang='en'], '/', $record//nuds:typeDesc/nuds:reverse/nuds:legend) } </reverse>
-								<published>false</published>
-							</record> 
-							else if ($type='nudsHoard') then
-							<record>
-								<type>{ $type }</type>
-								<maintenanceStatus> {$record/nh:nudsHoard/nh:control/nh:maintenanceStatus/text()}</maintenanceStatus>								
-								<publicationStatus>{data($record/nh:nuds/nh:control/nh:publicationStatus)}</publicationStatus>
-								<id>{ $record//nh:recordId/text() }</id>
-								<title>{ $record//nh:descMeta/nh:title[@xml:lang='en']/text() }</title>
-								<published>false</published>
-							</record>
-							else <record/> 
-						} </report>]]>
-                </query>
-                <query id="publish-all">
-                    <![CDATA[xquery version "1.0";
+						  for $record in collection()[contains(descendant::*[local-name()='recordId'], 'QUERY') or descendant::*[local-name()='title'] = 'QUERY'] let $type := $record/*/local-name()
+						  return if ($type='nuds') then 
+						  <record>
+						    <type>{ $type }</type>
+						    <maintenanceStatus>{$record/nuds:nuds/nuds:control/nuds:maintenanceStatus/text()}</maintenanceStatus>
+						    <publicationStatus>{data($record/nuds:nuds/nuds:control/nuds:publicationStatus)}</publicationStatus>
+						    <recordType>{ string($record/nuds:nuds/@recordType) }</recordType>
+						    <id>{ $record//nuds:recordId/text() }</id>
+						    <title>{$record//nuds:descMeta/nuds:title[@xml:lang='en']/text() }</title>
+						    <obverse> { concat($record//nuds:typeDesc/nuds:obverse/nuds:type/nuds:description[@xml:lang='en'], '/', $record//nuds:typeDesc/nuds:obverse/nuds:legend) } </obverse>
+						    <reverse> { concat($record//nuds:typeDesc/nuds:reverse/nuds:type/nuds:description[@xml:lang='en'], '/', $record//nuds:typeDesc/nuds:reverse/nuds:legend) } </reverse>
+						    <published>false</published>
+						  </record> 
+						  else if ($type='nudsHoard') then
+						  <record>
+						    <type>{ $type }</type>
+						    <maintenanceStatus> {$record/nh:nudsHoard/nh:control/nh:maintenanceStatus/text()}</maintenanceStatus>								
+						    <publicationStatus>{data($record/nh:nuds/nh:control/nh:publicationStatus)}</publicationStatus>
+						    <id>{ $record//nh:recordId/text() }</id>
+						    <title>{ $record//nh:descMeta/nh:title[@xml:lang='en']/text() }</title>
+						    <published>false</published>
+						  </record>
+						  else <record/> 
+						  } </report>]]>
+          </query>
+          <query id="publish-all">
+            <![CDATA[xquery version "1.0";
 						<report> { 
-							for $i at $position in collection()[descendant::*[local-name()='publicationStatus'] = 'approved' or descendant::*[local-name()='publicationStatus'] = 'approvedSubtype']
-								return concat(data($i//*:recordId), if ($position mod COUNT = 0) then ',' else '|') 
-							}
+						  for $i at $position in collection()[descendant::*[local-name()='publicationStatus'] = 'approved' or descendant::*[local-name()='publicationStatus'] = 'approvedSubtype']
+						  return concat(data($i//*:recordId), if ($position mod COUNT = 0) then ',' else '|') 
+						  }
 						</report>]]>
-                </query>
-            </queries>
-        </xforms:instance>
+          </query>
+        </queries>
+      </xforms:instance>
 
-        <xforms:instance id="pagination-result">
-            <exist:result/>
-        </xforms:instance>
+      <xforms:instance id="pagination-result">
+        <exist:result/>
+      </xforms:instance>
 
-        <xforms:instance id="xquery-result">
-            <exist:result/>
-        </xforms:instance>
+      <xforms:instance id="xquery-result">
+        <exist:result/>
+      </xforms:instance>
 
-        <!-- 3store query response -->
-        <xforms:instance id="3store-xquery-result">
-            <response xmlns="" />
-        </xforms:instance>
+      <!-- 3store query response -->
+      <xforms:instance id="3store-xquery-result">
+        <response xmlns="" />
+      </xforms:instance>
 
-        <!-- solr response for id query -->
-        <xforms:instance id="published-response">
-            <response xmlns="" />
-        </xforms:instance>
-        <xforms:instance id="list-published-response">
-            <response xmlns="" />
-        </xforms:instance>
-        <xforms:instance id="is-published">
-            <response xmlns="" />
-        </xforms:instance>
+      <!-- solr response for id query -->
+      <xforms:instance id="published-response">
+        <response xmlns="" />
+      </xforms:instance>
+      <xforms:instance id="list-published-response">
+        <response xmlns="" />
+      </xforms:instance>
+      <xforms:instance id="is-published">
+        <response xmlns="" />
+      </xforms:instance>
 
-        <!-- send to Solr -->
-        <xforms:instance id="addIndex" xxforms:exclude-result-prefixes="#all">
-            <add xmlns="" />
-        </xforms:instance>
+      <!-- send to Solr -->
+      <xforms:instance id="addIndex" xxforms:exclude-result-prefixes="#all">
+        <add xmlns="" />
+      </xforms:instance>
 
-        <!-- Instance for Solr commit-->
-        <xforms:instance id="sendCommit">
-            <commit/>
-        </xforms:instance>
+      <!-- Instance for Solr commit-->
+      <xforms:instance id="sendCommit">
+        <commit/>
+      </xforms:instance>
 
-        <!-- Solr optimize -->
-        <xforms:instance id="optimizeIndex">
-            <optimize/>
-        </xforms:instance>
+      <!-- Solr optimize -->
+      <xforms:instance id="optimizeIndex">
+        <optimize/>
+      </xforms:instance>
 
-        <!-- delete from Solr -->
-        <xforms:instance id="deleteId">
-            <delete xmlns="">
-                <query/>
-            </delete>
-        </xforms:instance>
-        <xforms:instance id="deleteAll">
-            <delete xmlns="">
-                <query/>
-            </delete>
-        </xforms:instance>
+      <!-- delete from Solr -->
+      <xforms:instance id="deleteId">
+        <delete xmlns="">
+          <query/>
+        </delete>
+      </xforms:instance>
+      <xforms:instance id="deleteAll">
+        <delete xmlns="">
+          <query/>
+        </delete>
+      </xforms:instance>
 
-        <xforms:instance id="dump">
-            <dump xmlns="" />
-        </xforms:instance>
+      <xforms:instance id="dump">
+        <dump xmlns="" />
+      </xforms:instance>
 
-        <!-- ************************* BINDINGS ************************** -->
-        <xforms:bind nodeset="instance('control-instance')">
-            <xforms:bind id="create-collection-trigger" nodeset="create-collection-trigger" type="xs:boolean" readonly=". != true()" />
+      <!-- ************************* BINDINGS ************************** -->
+      <xforms:bind nodeset="instance('control-instance')">
+        <xforms:bind id="create-collection-trigger" nodeset="create-collection-trigger" type="xs:boolean" readonly=". != true()" />
+      </xforms:bind>
+
+      <xforms:bind nodeset="instance('collections-list')" constraint="count(//@name) = count(distinct-values(//@name)) and count(//@role) = count(distinct-values(//@role))">
+        <xforms:bind nodeset="collection">
+          <xforms:bind nodeset="@name" required="true()" type="xs:ID" />
+          <xforms:bind nodeset="@role" required="true()" type="xs:ID" />
         </xforms:bind>
+      </xforms:bind>
 
-        <xforms:bind nodeset="instance('collections-list')" constraint="count(//@name) = count(distinct-values(//@name)) and count(//@role) = count(distinct-values(//@role))">
-            <xforms:bind nodeset="collection">
-                <xforms:bind nodeset="@name" required="true()" type="xs:ID" />
-                <xforms:bind nodeset="@role" required="true()" type="xs:ID" />
-            </xforms:bind>
+      <xforms:bind nodeset="instance('config-template')">
+        <xforms:bind nodeset="title" required="true()" />
+        <xforms:bind nodeset="description" required="true()" />
+        <xforms:bind nodeset="collection_type" required="true()" />
+        <xforms:bind nodeset="installation_path" required="true()" />
+        <xforms:bind nodeset="url" required="true()" constraint="matches(., 'https?://.+')" />
+        <xforms:bind nodeset="solr_published" required="true()" constraint="matches(., 'https?://.+')" />
+        <xforms:bind nodeset="template">
+          <!-- about the electronic record -->
+          <xforms:bind nodeset="agencyName" required="true()" />
+          <xforms:bind nodeset="language" required="true()" />
+          <xforms:bind nodeset="license" required="true()" />
+          <xforms:bind nodeset="rights" required="true()" />
         </xforms:bind>
+      </xforms:bind>
 
-        <xforms:bind nodeset="instance('config-template')">
-            <xforms:bind nodeset="title" required="true()" />
-            <xforms:bind nodeset="description" required="true()" />
-            <xforms:bind nodeset="collection_type" required="true()" />
-            <xforms:bind nodeset="installation_path" required="true()" />
-            <xforms:bind nodeset="url" required="true()" constraint="matches(., 'https?://.+')" />
-            <xforms:bind nodeset="solr_published" required="true()" constraint="matches(., 'https?://.+')" />
-            <xforms:bind nodeset="template">
-                <!-- about the electronic record -->
-                <xforms:bind nodeset="agencyName" required="true()" />
-                <xforms:bind nodeset="language" required="true()" />
-                <xforms:bind nodeset="license" required="true()" />
-                <xforms:bind nodeset="rights" required="true()" />
-            </xforms:bind>
+      <xforms:bind nodeset="instance('config')">
+        <xforms:bind nodeset="union_type_catalog">
+          <xforms:bind nodeset="@enabled" type="xs:boolean" />
         </xforms:bind>
+      </xforms:bind>
 
-        <xforms:bind nodeset="instance('config')">
-            <xforms:bind nodeset="union_type_catalog">
-                <xforms:bind nodeset="@enabled" type="xs:boolean" />
-            </xforms:bind>
+      <xforms:bind nodeset="instance('pagination-result')">
+        <xforms:bind nodeset="//record">
+          <xforms:bind nodeset="published" type="xs:boolean" readonly="../publicationStatus = 'approvedSubtype'" />
         </xforms:bind>
-
-        <xforms:bind nodeset="instance('pagination-result')">
-            <xforms:bind nodeset="//record">
-                <xforms:bind nodeset="published" type="xs:boolean" readonly="../publicationStatus = 'approvedSubtype'" />
-            </xforms:bind>
-        </xforms:bind>
+      </xforms:bind>
 
 
-        <xforms:bind nodeset="instance('3store-xquery-result')" type="xxforms:xml" />
+      <xforms:bind nodeset="instance('3store-xquery-result')" type="xxforms:xml" />
 
 
-        <!-- **************** DYNAMIC VALIDATION CONTROLS ********************** -->
-        <xforms:action ev:event="xxforms-invalid" ev:observer="collections-list">
-            <xforms:setvalue ref="instance('control-instance')/create-collection-trigger" value="false()" />
+      <!-- **************** DYNAMIC VALIDATION CONTROLS ********************** -->
+      <xforms:action ev:event="xxforms-invalid" ev:observer="collections-list">
+        <xforms:setvalue ref="instance('control-instance')/create-collection-trigger" value="false()" />
+      </xforms:action>
+
+      <xforms:action ev:event="xxforms-valid" ev:observer="collections-list">
+        <xforms:setvalue ref="instance('control-instance')/create-collection-trigger" value="true()" if="xxforms:valid(instance('config-template'), true())" />
+      </xforms:action>
+
+      <xforms:action ev:event="xxforms-invalid" ev:observer="config-template">
+        <xforms:setvalue ref="instance('control-instance')/create-collection-trigger" value="false()" />
+      </xforms:action>
+
+      <xforms:action ev:event="xxforms-valid" ev:observer="config-template">
+        <xforms:setvalue ref="instance('control-instance')/create-collection-trigger" value="true()" if="xxforms:valid(instance('collections-list'), true())" />
+      </xforms:action>
+
+      <!-- ************************* SUBMISSIONS ************************** -->
+      <!-- load collections/roles config -->
+      <xforms:submission id="load-collections" serialization="none" method="get" resource="{instance('exist-config')/url}collections-list.xml" replace="instance" instance="collections-list" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
+        <!-- if the config loads successfully, set the collection names based on authentication -->
+        <xforms:action ev:event="xforms-submit-done">
+          <!-- proceed with setting the interface for collection editing -->
+          <xforms:action if="not(instance('control-instance')/request-security/role = 'numishare-admin')">
+            <!-- if there is an eXist-db collection name that matches the associated Tomcat role -->
+            <xforms:action if="string(instance('collections-list')/collection[@role=instance('control-instance')/request-security/role]/@name)">
+              <xforms:setvalue ref="instance('control-instance')/collection-name" value="instance('collections-list')/collection[@role=instance('control-instance')/request-security/role]/@name" />
+              <!-- set interface -->
+              <xforms:setvalue ref="instance('control-instance')/interface">numishare-editor</xforms:setvalue>
+              <!-- load config -->
+              <xforms:send submission="load-config" />
+            </xforms:action>
+            <!-- if there is not a collection matching the role, display the appropriate interface -->
+            <xforms:action if="not(string(instance('collections-list')/collection[@role=instance('control-instance')/request-security/role]/@name))">
+              <!-- set interface -->
+              <xforms:setvalue ref="instance('control-instance')/interface">unauthorized-user</xforms:setvalue>
+            </xforms:action>
+          </xforms:action>
+          <xforms:action if="instance('control-instance')/request-security/role = 'numishare-admin'">
+            <!-- get collection metadata -->
+            <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='collection-metadata'], '%SEQUENCE%', string-join(instance('collections-list')/collection/@name, ','))" />
+            <xforms:send submission="xquery-db" />
+
+            <!-- set interface: if there is a session attribute for collection-name, then load the editor interface. otherwise load numishare-admin interface -->
+            <xforms:action if="string(xxforms:get-session-attribute('collection-name'))">
+              <xforms:setvalue ref="instance('control-instance')/collection-name" value="xxforms:get-session-attribute('collection-name')" />
+              <xforms:setvalue ref="instance('control-instance')/interface">numishare-editor</xforms:setvalue>
+              <xforms:send submission="load-config" />
+            </xforms:action>
+            <xforms:action if="not(string(xxforms:get-session-attribute('collection-name')))">
+              <xforms:setvalue ref="instance('control-instance')/interface">numishare-admin</xforms:setvalue>
+            </xforms:action>
+
+          </xforms:action>
+        </xforms:action>
+        <!-- if there isn't a collection list XML, then this is the first time Numishare has been run. If the role is numishare-admin display the collection creation interface, otherwise block editing to unauthorized individuals -->
+        <xforms:action ev:event="xforms-submit-error">
+          <!-- set interface -->
+          <xforms:setvalue ref="instance('control-instance')/interface">numishare-admin</xforms:setvalue>
+        </xforms:action>
+      </xforms:submission>
+
+      <xforms:submission id="save-collections" ref="instance('collections-list')" resource="{instance('exist-config')/url}/collections-list.xml" method="put" replace="none" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
+        <xforms:message ev:event="xforms-submit-error" level="modal">Error Saving Collections List.</xforms:message>
+      </xforms:submission>
+
+      <!-- loading, saving config -->
+      <xforms:submission id="load-config" serialization="none" method="get" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/config.xml" replace="instance" instance="config" xxforms:username="{instance('exist-config')/username}"
+			 xxforms:password="{instance('exist-config')/password}">
+        <xforms:action ev:event="xforms-submit-done">
+
+          <!-- evaluate the config to identify whether it is a union type corpus or not -->
+          <xforms:action if="instance('config')/union_type_catalog/@enabled = true()">
+            <xforms:toggle case="union_type_catalog" />
+          </xforms:action>
+          <xforms:action if="not(instance('config')/union_type_catalog/@enabled = true())">
+            <!-- get the number of docs in the eXist collection() -->
+            <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="instance('xqueries')/query[@id='collection-count']" />
+            <xforms:send submission="xquery-collection" />
+            <xforms:setvalue ref="instance('control-instance')/numFound" value="number(instance('xquery-result'))" />
+            <!-- set value in control instance -->
+
+            <xforms:var name="end" select="if(instance('control-instance')/numFound &gt; 20) then 20 else instance('control-instance')/numFound" />
+            <!-- get list of files for page 1, replacing START and END -->
+            <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')" />
+            <xforms:send submission="xquery-pagination" />
+
+            <xforms:toggle case="collection-interface" />
+          </xforms:action>
+        </xforms:action>
+        <!-- if config.xml doesn't exist, then create the exist collection with necessary files -->
+        <xforms:message ev:event="xforms-submit-error" level="model">Error: there is no config for this collection.</xforms:message>
+      </xforms:submission>
+
+      <xforms:submission id="save-config" ref="instance('config-template')" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/config.xml" method="put" replace="none" xxforms:username="{instance('exist-config')/username}"
+			 xxforms:password="{instance('exist-config')/password}">
+        <xforms:message ev:event="xforms-submit-error" level="modal">Error Saving Config.</xforms:message>
+        <xforms:action ev:event="xforms-submit-done">
+          <!-- create eXist-db collections, config file, and XQuery files -->
+          <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(replace(instance('xqueries')/query[@id='create-collection'], '%COLLECTION%', instance('control-instance')/collection-name), '%PATH%', instance('config-template')/installation_path)"
+			   />
+          <xforms:send submission="xquery-db" />
+
+          <!-- submit collection metadata once again before switching the interface -->
+          <xforms:action ev:event="xforms-submit-done">
+            <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='collection-metadata'], '%SEQUENCE%', string-join(instance('collections-list')/collection/@name, ','))" />
+            <xforms:send submission="xquery-db" />
+          </xforms:action>
+        </xforms:action>
+      </xforms:submission>
+
+      <!--***************** XQUERY ******************-->
+      <!-- xquery for getting and processing query results into pages of items -->
+      <xforms:submission id="xquery-pagination" ref="instance('eXist-xquery')" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects" method="post" replace="instance" instance="pagination-result" xxforms:username="{instance('exist-config')/username}"
+			 xxforms:password="{instance('exist-config')/password}">
+        <xforms:setvalue ref="instance('control-instance')/error" ev:event="xforms-submit-error">Error querying eXist database.</xforms:setvalue>
+        <xforms:action ev:event="xforms-submit-done">
+          <!--iterate through docs, check for publication -->
+          <xforms:action xxforms:iterate="instance('pagination-result')//record">
+            <xforms:setvalue ref="instance('control-instance')/id" value="context()/id" />
+            <xforms:send submission="query-solr-for-publication" />
+          </xforms:action>
+        </xforms:action>
+      </xforms:submission>
+
+      <xforms:submission id="xquery-collection" ref="instance('eXist-xquery')" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects" method="post" replace="instance" instance="xquery-result" xxforms:username="{instance('exist-config')/username}"
+			 xxforms:password="{instance('exist-config')/password}">
+        <xforms:setvalue ref="instance('control-instance')/error" ev:event="xforms-submit-error">Error querying eXist database.</xforms:setvalue>
+      </xforms:submission>
+
+      <xforms:submission id="xquery-db" ref="instance('eXist-xquery')" resource="{instance('exist-config')/url}" method="post" replace="instance" instance="xquery-result" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
+        <xforms:setvalue ref="instance('control-instance')/error" ev:event="xforms-submit-error">Error querying eXist database.</xforms:setvalue>
+      </xforms:submission>
+      <!-- ************************* CRUD ON OBJECT RECORDS ********************** -->
+      <!-- update publication status -->
+      <xforms:submission id="load-object" serialization="none" method="get" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects/{instance('control-instance')/id}.xml" xxforms:username="{instance('exist-config')/username}"
+			 xxforms:password="{instance('exist-config')/password}" replace="instance" instance="object">
+        <xforms:message ev:event="xforms-submit-error" level="modal">Error loading file.</xforms:message>
+        <xforms:action ev:event="xforms-submit-done">
+          <xforms:setvalue ref="instance('object')/nuds:control/nuds:publicationStatus" value="instance('control-instance')/publicationStatus" />
+          <xforms:send submission="save-object" />
+        </xforms:action>
+      </xforms:submission>
+
+      <xforms:submission id="save-object" ref="instance('object')" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects/{instance('control-instance')/id}.xml"
+			 method="put" replace="none">
+        <xforms:message ev:event="xforms-submit-error" level="modal">Error saving file.</xforms:message>
+      </xforms:submission>
+
+      <xforms:submission id="delete-object" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects/{instance('control-instance')/id}.xml" method="delete" replace="none" xxforms:username="{instance('exist-config')/username}"
+			 xxforms:password="{instance('exist-config')/password}">
+        <xforms:setvalue ev:event="xforms-submit-done" ref="instance('control-instance')/status">Object successfully deleted.</xforms:setvalue>
+      </xforms:submission>
+
+      <!-- ************************* SOLR SUBMISSIONS ************************** -->
+      <!-- query Solr for the id of all currently published documents and repost them to solr -->
+      <xforms:submission id="republish" serialization="none" method="get" resource="{instance('config')/solr_published}select/?q=collection-name:{instance('control-instance')/collection-name}&amp;rows=100000&amp;start=0&amp;fl=id" replace="instance" instance="list-published-response">
+        <xforms:message ev:event="xforms-submit-error" level="modal">Solr is inaccessible. Please check Solr configuration. [ADM001]</xforms:message>
+        <xforms:action ev:event="xforms-submit-done">
+          <xforms:setvalue ref="instance('control-instance')/identifiers" value="string-join(instance('list-published-response')//doc/str[@name='id'], '|')" />
+
+          <!-- get Solr document -->
+          <xforms:send submission="generate-add-document" />
+          <!-- optimize index -->
+          <xforms:send submission="optimize" />
+          <!-- reload table -->
+          <xforms:delete nodeset="instance('list')/*" />
+          <xforms:send submission="query-solr" />
+        </xforms:action>
+      </xforms:submission>
+      <!-- access service to read in pre-transformed solr doc -->
+      <xforms:submission id="nuds-to-solr" method="get" replace="instance" instance="addIndex" serialization="none" resource="/numishare/{instance('control-instance')/collection-name}/id/{instance('control-instance')/id}.solr">
+        <xforms:message ev:event="xforms-submit-error" level="modal">Error transforming XML record to Solr document.</xforms:message>
+        <xforms:send ev:event="xforms-submit-done" submission="post-solr-doc" />
+      </xforms:submission>
+
+      <!-- post instance to Solr -->
+      <xforms:submission id="post-solr-doc" resource="{instance('config')/solr_published}update" ref="instance('addIndex')" instance="addIndex" replace="instance" method="post">
+        <xforms:message ev:event="xforms-submit-error" level="modal">Data Failed to POST to Solr. Index may be offline or URL is incorrect.</xforms:message>
+        <xforms:setvalue ev:event="xforms-submit-done" ref="instance('control-instance')/status">Successfully published to Solr.</xforms:setvalue>
+      </xforms:submission>
+
+      <!-- delete from Solr -->
+      <xforms:submission id="delete-solr-doc" resource="{instance('config')/solr_published}update" ref="instance('deleteId')" instance="deleteId" replace="none" method="post">
+        <xforms:action ev:event="xforms-submit-done">
+          <xforms:setvalue ref="instance('control-instance')/status">Successfully deleted document from Solr.</xforms:setvalue>
+          <xforms:send submission="submit-commit" />
+        </xforms:action>
+        <xforms:message ev:event="xforms-submit-error" level="modal">Data Failed to POST to Solr.</xforms:message>
+      </xforms:submission>
+
+      <xforms:submission id="delete-all" resource="{instance('config')/solr_published}update" ref="instance('deleteAll')" instance="deleteAll" replace="none" method="post">
+        <xforms:message ev:event="xforms-submit-error" level="modal">Error issuing delete query</xforms:message>
+        <xforms:action ev:event="xforms-submit-done">
+          <xforms:send submission="submit-commit" />
+          <xforms:setvalue ref="instance('control-instance')/status">Objects removed from search index.</xforms:setvalue>
+        </xforms:action>
+      </xforms:submission>
+
+      <!-- pass identifiers URL parameter to xquery process in Cocoon to generate large Solr add document -->
+      <xforms:submission id="generate-add-document" method="get" replace="instance" instance="addIndex" serialization="none" resource="/numishare/{instance('control-instance')/collection-name}/ingest?identifiers={instance('control-instance')/identifiers}">
+        <xforms:message ev:event="xforms-submit-error" level="modal">Error getting Solr document from XQuery ingestion pipeline.</xforms:message>
+        <xforms:action ev:event="xforms-submit-done">
+          <xforms:send submission="post-solr-doc" />
+        </xforms:action>
+      </xforms:submission>
+
+      <!-- send commit -->
+      <xforms:submission id="submit-commit" resource="{instance('config')/solr_published}update" ref="instance('sendCommit')" instance="sendCommit" replace="none" method="post">
+        <xforms:message ev:event="xforms-submit-error" level="modal">Failed to commit to Solr index.</xforms:message>
+      </xforms:submission>
+
+      <!-- send optimize -->
+      <xforms:submission id="optimize" resource="{instance('config')/solr_published}update" ref="instance('optimizeIndex')" instance="optimizeIndex" replace="none" method="post">
+        <xforms:message ev:event="xforms-submit-error" level="modal">Failed to optimize Solr index.</xforms:message>
+      </xforms:submission>
+
+      <!-- submission to query solr to see if the document is published -->
+      <xforms:submission id="query-solr-for-publication" serialization="none" method="get" resource="{instance('config')/solr_published}select/?q=collection-name:{instance('control-instance')/collection-name} AND id:&#x022;{instance('control-instance')/id}&#x022;"
+			 replace="instance" instance="published-response">
+        <!-- if the document is found in solr, get the updated solr doc -->
+        <xforms:setvalue ev:event="xforms-submit-done" if="instance('published-response')/result[@name='response']/@numFound = '1'" ref="instance('pagination-result')//record[id=instance('control-instance')/id]/published" value="true()" />
+      </xforms:submission>
+
+      <!-- ************************* EXIST SUBMISSIONS FOR POSTING TO TRIPLE STORE************************** -->
+      <xforms:submission id="post-to-3store" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/post-to-3store.xq" serialization="none" method="get" replace="instance" instance="3store-xquery-result" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
+
+        <xforms:action ev:event="xforms-submit-error">
+          <xforms:setvalue ref="instance('control-instance')/status" value="event('response-body')" />
+          <xforms:message level="modal">Error posting to 3store.</xforms:message>
+        </xforms:action>
+        <xforms:action ev:event="xforms-submit-done">
+          <xforms:action if="number(instance('xquery-result'))">
+            <xforms:setvalue ref="instance('control-instance')/status">Successfully posted to 3store.</xforms:setvalue>
+          </xforms:action>
+        </xforms:action>
+      </xforms:submission>
+
+      <xforms:submission id="delete-all-from-3store" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/delete-from-3store.xq" serialization="none" method="get" replace="instance" instance="3store-xquery-result" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
+        <xforms:message ev:event="xforms-submit-error" level="modal">Error deleting from 3store.</xforms:message>
+        <xforms:action ev:event="xforms-submit-done">
+          <xforms:action if="number(instance('xquery-result'))">
+            <xforms:setvalue ref="instance('control-instance')/status">Successfully deleted all from 3store.</xforms:setvalue>
+          </xforms:action>
         </xforms:action>
 
-        <xforms:action ev:event="xxforms-valid" ev:observer="collections-list">
-            <xforms:setvalue ref="instance('control-instance')/create-collection-trigger" value="true()" if="xxforms:valid(instance('config-template'), true())" />
+      </xforms:submission>
+
+
+      <!-- ************************* XFORMS-MODEL-CONSTRUCT-DONE ************************** -->
+      <xforms:action ev:event="xforms-model-construct-done">
+        <!-- load numishare config file on xforms construction -->
+        <xforms:insert context="instance('control-instance')" nodeset="collection-name" position="after" origin="xxforms:call-xpl('oxf:/apps/numishare/xpl/get-authentication.xpl', 'dump', instance('dump'), 'data')" />
+
+        <!-- if authentication has not been enabled, trigger a case -->
+        <xforms:action if="not(string(instance('control-instance')/request-security/role))">
+          <!-- set interface -->
+          <xforms:setvalue ref="instance('control-instance')/interface">unauthorized-user</xforms:setvalue>
         </xforms:action>
-
-        <xforms:action ev:event="xxforms-invalid" ev:observer="config-template">
-            <xforms:setvalue ref="instance('control-instance')/create-collection-trigger" value="false()" />
+        <xforms:action if="string(instance('control-instance')/request-security/role)">
+          <xforms:send submission="load-collections" />
         </xforms:action>
+      </xforms:action>
 
-        <xforms:action ev:event="xxforms-valid" ev:observer="config-template">
-            <xforms:setvalue ref="instance('control-instance')/create-collection-trigger" value="true()" if="xxforms:valid(instance('collections-list'), true())" />
-        </xforms:action>
-
-        <!-- ************************* SUBMISSIONS ************************** -->
-        <!-- load collections/roles config -->
-        <xforms:submission id="load-collections" serialization="none" method="get" resource="{instance('exist-config')/url}collections-list.xml" replace="instance" instance="collections-list" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
-            <!-- if the config loads successfully, set the collection names based on authentication -->
-            <xforms:action ev:event="xforms-submit-done">
-                <!-- proceed with setting the interface for collection editing -->
-                <xforms:action if="not(instance('control-instance')/request-security/role = 'numishare-admin')">
-                    <!-- if there is an eXist-db collection name that matches the associated Tomcat role -->
-                    <xforms:action if="string(instance('collections-list')/collection[@role=instance('control-instance')/request-security/role]/@name)">
-                        <xforms:setvalue ref="instance('control-instance')/collection-name" value="instance('collections-list')/collection[@role=instance('control-instance')/request-security/role]/@name" />
-                        <!-- set interface -->
-                        <xforms:setvalue ref="instance('control-instance')/interface">numishare-editor</xforms:setvalue>
-                        <!-- load config -->
-                        <xforms:send submission="load-config" />
-                    </xforms:action>
-                    <!-- if there is not a collection matching the role, display the appropriate interface -->
-                    <xforms:action if="not(string(instance('collections-list')/collection[@role=instance('control-instance')/request-security/role]/@name))">
-                        <!-- set interface -->
-                        <xforms:setvalue ref="instance('control-instance')/interface">unauthorized-user</xforms:setvalue>
-                    </xforms:action>
-                </xforms:action>
-                <xforms:action if="instance('control-instance')/request-security/role = 'numishare-admin'">
-                    <!-- get collection metadata -->
-                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='collection-metadata'], '%SEQUENCE%', string-join(instance('collections-list')/collection/@name, ','))" />
-                    <xforms:send submission="xquery-db" />
-
-                    <!-- set interface: if there is a session attribute for collection-name, then load the editor interface. otherwise load numishare-admin interface -->
-                    <xforms:action if="string(xxforms:get-session-attribute('collection-name'))">
-                        <xforms:setvalue ref="instance('control-instance')/collection-name" value="xxforms:get-session-attribute('collection-name')" />
-                        <xforms:setvalue ref="instance('control-instance')/interface">numishare-editor</xforms:setvalue>
-                        <xforms:send submission="load-config" />
-                    </xforms:action>
-                    <xforms:action if="not(string(xxforms:get-session-attribute('collection-name')))">
-                        <xforms:setvalue ref="instance('control-instance')/interface">numishare-admin</xforms:setvalue>
-                    </xforms:action>
-
-                </xforms:action>
-            </xforms:action>
-            <!-- if there isn't a collection list XML, then this is the first time Numishare has been run. If the role is numishare-admin display the collection creation interface, otherwise block editing to unauthorized individuals -->
-            <xforms:action ev:event="xforms-submit-error">
-                <!-- set interface -->
-                <xforms:setvalue ref="instance('control-instance')/interface">numishare-admin</xforms:setvalue>
-            </xforms:action>
-        </xforms:submission>
-
-        <xforms:submission id="save-collections" ref="instance('collections-list')" resource="{instance('exist-config')/url}/collections-list.xml" method="put" replace="none" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
-            <xforms:message ev:event="xforms-submit-error" level="modal">Error Saving Collections List.</xforms:message>
-        </xforms:submission>
-
-        <!-- loading, saving config -->
-        <xforms:submission id="load-config" serialization="none" method="get" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/config.xml" replace="instance" instance="config" xxforms:username="{instance('exist-config')/username}"
-            xxforms:password="{instance('exist-config')/password}">
-            <xforms:action ev:event="xforms-submit-done">
-
-                <!-- evaluate the config to identify whether it is a union type corpus or not -->
-                <xforms:action if="instance('config')/union_type_catalog/@enabled = true()">
-                    <xforms:toggle case="union_type_catalog" />
-                </xforms:action>
-                <xforms:action if="not(instance('config')/union_type_catalog/@enabled = true())">
-                    <!-- get the number of docs in the eXist collection() -->
-                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="instance('xqueries')/query[@id='collection-count']" />
-                    <xforms:send submission="xquery-collection" />
-                    <xforms:setvalue ref="instance('control-instance')/numFound" value="number(instance('xquery-result'))" />
-                    <!-- set value in control instance -->
-
-                    <xforms:var name="end" select="if(instance('control-instance')/numFound &gt; 20) then 20 else instance('control-instance')/numFound" />
-                    <!-- get list of files for page 1, replacing START and END -->
-                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')" />
-                    <xforms:send submission="xquery-pagination" />
-
-                    <xforms:toggle case="collection-interface" />
-                </xforms:action>
-            </xforms:action>
-            <!-- if config.xml doesn't exist, then create the exist collection with necessary files -->
-            <xforms:message ev:event="xforms-submit-error" level="model">Error: there is no config for this collection.</xforms:message>
-        </xforms:submission>
-
-        <xforms:submission id="save-config" ref="instance('config-template')" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/config.xml" method="put" replace="none" xxforms:username="{instance('exist-config')/username}"
-            xxforms:password="{instance('exist-config')/password}">
-            <xforms:message ev:event="xforms-submit-error" level="modal">Error Saving Config.</xforms:message>
-            <xforms:action ev:event="xforms-submit-done">
-                <!-- create eXist-db collections, config file, and XQuery files -->
-                <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(replace(instance('xqueries')/query[@id='create-collection'], '%COLLECTION%', instance('control-instance')/collection-name), '%PATH%', instance('config-template')/installation_path)"
-                />
-                <xforms:send submission="xquery-db" />
-
-                <!-- submit collection metadata once again before switching the interface -->
-                <xforms:action ev:event="xforms-submit-done">
-                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='collection-metadata'], '%SEQUENCE%', string-join(instance('collections-list')/collection/@name, ','))" />
-                    <xforms:send submission="xquery-db" />
-                </xforms:action>
-            </xforms:action>
-        </xforms:submission>
-
-        <!--***************** XQUERY ******************-->
-        <!-- xquery for getting and processing query results into pages of items -->
-        <xforms:submission id="xquery-pagination" ref="instance('eXist-xquery')" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects" method="post" replace="instance" instance="pagination-result" xxforms:username="{instance('exist-config')/username}"
-            xxforms:password="{instance('exist-config')/password}">
-            <xforms:setvalue ref="instance('control-instance')/error" ev:event="xforms-submit-error">Error querying eXist database.</xforms:setvalue>
-            <xforms:action ev:event="xforms-submit-done">
-                <!--iterate through docs, check for publication -->
-                <xforms:action xxforms:iterate="instance('pagination-result')//record">
-                    <xforms:setvalue ref="instance('control-instance')/id" value="context()/id" />
-                    <xforms:send submission="query-solr-for-publication" />
-                </xforms:action>
-            </xforms:action>
-        </xforms:submission>
-
-        <xforms:submission id="xquery-collection" ref="instance('eXist-xquery')" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects" method="post" replace="instance" instance="xquery-result" xxforms:username="{instance('exist-config')/username}"
-            xxforms:password="{instance('exist-config')/password}">
-            <xforms:setvalue ref="instance('control-instance')/error" ev:event="xforms-submit-error">Error querying eXist database.</xforms:setvalue>
-        </xforms:submission>
-
-        <xforms:submission id="xquery-db" ref="instance('eXist-xquery')" resource="{instance('exist-config')/url}" method="post" replace="instance" instance="xquery-result" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
-            <xforms:setvalue ref="instance('control-instance')/error" ev:event="xforms-submit-error">Error querying eXist database.</xforms:setvalue>
-        </xforms:submission>
-        <!-- ************************* CRUD ON OBJECT RECORDS ********************** -->
-        <!-- update publication status -->
-        <xforms:submission id="load-object" serialization="none" method="get" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects/{instance('control-instance')/id}.xml" xxforms:username="{instance('exist-config')/username}"
-            xxforms:password="{instance('exist-config')/password}" replace="instance" instance="object">
-            <xforms:message ev:event="xforms-submit-error" level="modal">Error loading file.</xforms:message>
-            <xforms:action ev:event="xforms-submit-done">
-                <xforms:setvalue ref="instance('object')/nuds:control/nuds:publicationStatus" value="instance('control-instance')/publicationStatus" />
-                <xforms:send submission="save-object" />
-            </xforms:action>
-        </xforms:submission>
-
-        <xforms:submission id="save-object" ref="instance('object')" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects/{instance('control-instance')/id}.xml"
-            method="put" replace="none">
-            <xforms:message ev:event="xforms-submit-error" level="modal">Error saving file.</xforms:message>
-        </xforms:submission>
-
-        <xforms:submission id="delete-object" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects/{instance('control-instance')/id}.xml" method="delete" replace="none" xxforms:username="{instance('exist-config')/username}"
-            xxforms:password="{instance('exist-config')/password}">
-            <xforms:setvalue ev:event="xforms-submit-done" ref="instance('control-instance')/status">Object successfully deleted.</xforms:setvalue>
-        </xforms:submission>
-
-        <!-- ************************* SOLR SUBMISSIONS ************************** -->
-        <!-- query Solr for the id of all currently published documents and repost them to solr -->
-        <xforms:submission id="republish" serialization="none" method="get" resource="{instance('config')/solr_published}select/?q=collection-name:{instance('control-instance')/collection-name}&amp;rows=100000&amp;start=0&amp;fl=id" replace="instance" instance="list-published-response">
-            <xforms:message ev:event="xforms-submit-error" level="modal">Solr is inaccessible. Please check Solr configuration. [ADM001]</xforms:message>
-            <xforms:action ev:event="xforms-submit-done">
-                <xforms:setvalue ref="instance('control-instance')/identifiers" value="string-join(instance('list-published-response')//doc/str[@name='id'], '|')" />
-
-                <!-- get Solr document -->
-                <xforms:send submission="generate-add-document" />
-                <!-- optimize index -->
-                <xforms:send submission="optimize" />
-                <!-- reload table -->
-                <xforms:delete nodeset="instance('list')/*" />
-                <xforms:send submission="query-solr" />
-            </xforms:action>
-        </xforms:submission>
-        <!-- access service to read in pre-transformed solr doc -->
-        <xforms:submission id="nuds-to-solr" method="get" replace="instance" instance="addIndex" serialization="none" resource="/numishare/{instance('control-instance')/collection-name}/id/{instance('control-instance')/id}.solr">
-            <xforms:message ev:event="xforms-submit-error" level="modal">Error transforming XML record to Solr document.</xforms:message>
-            <xforms:send ev:event="xforms-submit-done" submission="post-solr-doc" />
-        </xforms:submission>
-
-        <!-- post instance to Solr -->
-        <xforms:submission id="post-solr-doc" resource="{instance('config')/solr_published}update" ref="instance('addIndex')" instance="addIndex" replace="instance" method="post">
-            <xforms:message ev:event="xforms-submit-error" level="modal">Data Failed to POST to Solr. Index may be offline or URL is incorrect.
-            </xforms:message>
-            <xforms:setvalue ev:event="xforms-submit-done" ref="instance('control-instance')/status">Successfully published to Solr.</xforms:setvalue>
-        </xforms:submission>
-
-        <!-- delete from Solr -->
-        <xforms:submission id="delete-solr-doc" resource="{instance('config')/solr_published}update" ref="instance('deleteId')" instance="deleteId" replace="none" method="post">
-            <xforms:action ev:event="xforms-submit-done">
-                <xforms:setvalue ref="instance('control-instance')/status">Successfully deleted document from Solr.</xforms:setvalue>
-                <xforms:send submission="submit-commit" />
-            </xforms:action>
-            <xforms:message ev:event="xforms-submit-error" level="modal">Data Failed to POST to Solr.</xforms:message>
-        </xforms:submission>
-
-        <xforms:submission id="delete-all" resource="{instance('config')/solr_published}update" ref="instance('deleteAll')" instance="deleteAll" replace="none" method="post">
-            <xforms:message ev:event="xforms-submit-error" level="modal">Error issuing delete query</xforms:message>
-            <xforms:action ev:event="xforms-submit-done">
-                <xforms:send submission="submit-commit" />
-                <xforms:setvalue ref="instance('control-instance')/status">Objects removed from search index.</xforms:setvalue>
-            </xforms:action>
-        </xforms:submission>
-
-        <!-- pass identifiers URL parameter to xquery process in Cocoon to generate large Solr add document -->
-        <xforms:submission id="generate-add-document" method="get" replace="instance" instance="addIndex" serialization="none" resource="/numishare/{instance('control-instance')/collection-name}/ingest?identifiers={instance('control-instance')/identifiers}">
-            <xforms:message ev:event="xforms-submit-error" level="modal">Error getting Solr document from XQuery ingestion pipeline.</xforms:message>
-            <xforms:action ev:event="xforms-submit-done">
-                <xforms:send submission="post-solr-doc" />
-            </xforms:action>
-        </xforms:submission>
-
-        <!-- send commit -->
-        <xforms:submission id="submit-commit" resource="{instance('config')/solr_published}update" ref="instance('sendCommit')" instance="sendCommit" replace="none" method="post">
-            <xforms:message ev:event="xforms-submit-error" level="modal">Failed to commit to Solr index.</xforms:message>
-        </xforms:submission>
-
-        <!-- send optimize -->
-        <xforms:submission id="optimize" resource="{instance('config')/solr_published}update" ref="instance('optimizeIndex')" instance="optimizeIndex" replace="none" method="post">
-            <xforms:message ev:event="xforms-submit-error" level="modal">Failed to optimize Solr index.</xforms:message>
-        </xforms:submission>
-
-        <!-- submission to query solr to see if the document is published -->
-        <xforms:submission id="query-solr-for-publication" serialization="none" method="get" resource="{instance('config')/solr_published}select/?q=collection-name:{instance('control-instance')/collection-name} AND id:&#x022;{instance('control-instance')/id}&#x022;"
-            replace="instance" instance="published-response">
-            <!-- if the document is found in solr, get the updated solr doc -->
-            <xforms:setvalue ev:event="xforms-submit-done" if="instance('published-response')/result[@name='response']/@numFound = '1'" ref="instance('pagination-result')//record[id=instance('control-instance')/id]/published" value="true()" />
-        </xforms:submission>
-
-        <!-- ************************* EXIST SUBMISSIONS FOR POSTING TO TRIPLE STORE************************** -->
-        <xforms:submission id="post-to-3store" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/post-to-3store.xq" serialization="none" method="get" replace="instance" instance="3store-xquery-result" xxforms:username="{instance('exist-config')/username}"
-            xxforms:password="{instance('exist-config')/password}">
-
-            <xforms:action ev:event="xforms-submit-error">
-                <xforms:setvalue ref="instance('control-instance')/status" value="event('response-body')" />
-                <xforms:message level="modal">
-                    Error posting to 3store.
-                </xforms:message>
-            </xforms:action>
-            <xforms:action ev:event="xforms-submit-done">
-                <xforms:action if="number(instance('xquery-result'))">
-                    <xforms:setvalue ref="instance('control-instance')/status">Successfully posted to 3store.</xforms:setvalue>
-                </xforms:action>
-            </xforms:action>
-        </xforms:submission>
-        <!-- ************************* XFORMS-MODEL-CONSTRUCT-DONE ************************** -->
-        <xforms:action ev:event="xforms-model-construct-done">
-            <!-- load numishare config file on xforms construction -->
-            <xforms:insert context="instance('control-instance')" nodeset="collection-name" position="after" origin="xxforms:call-xpl('oxf:/apps/numishare/xpl/get-authentication.xpl', 'dump', instance('dump'), 'data')" />
-
-            <!-- if authentication has not been enabled, trigger a case -->
-            <xforms:action if="not(string(instance('control-instance')/request-security/role))">
-                <!-- set interface -->
-                <xforms:setvalue ref="instance('control-instance')/interface">unauthorized-user</xforms:setvalue>
-            </xforms:action>
-            <xforms:action if="string(instance('control-instance')/request-security/role)">
-                <xforms:send submission="load-collections" />
-            </xforms:action>
-        </xforms:action>
-
-        <!-- ************************* XFORMS-READY ************************** -->
-        <!-- set case on xforms-ready -->
-        <xforms:action ev:event="xforms-ready">
-            <xforms:toggle case="{instance('control-instance')/interface}" />
-        </xforms:action>
+      <!-- ************************* XFORMS-READY ************************** -->
+      <!-- set case on xforms-ready -->
+      <xforms:action ev:event="xforms-ready">
+        <xforms:toggle case="{instance('control-instance')/interface}" />
+      </xforms:action>
     </xforms:model>
-</head>
+  </head>
 
-<body>
+  <body>
     <xforms:var name="display_path">./</xforms:var>
     <xforms:group ref=".[not(instance('control-instance')/interface = 'unauthorized-user')]">
-        <xi:include href="header.xml" />
+      <xi:include href="header.xml" />
     </xforms:group>
     <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-12">
+      <div class="row">
+        <div class="col-md-12">
+          <xforms:switch>
+            <xforms:case id="unauthorized-user">
+              <h2>Unauthorized User</h2>
+              <p>You are seeing this interface either because authentication has not been enabled for the Numishare administrative panel or there is no matching eXist-db collection for your role. If it is the latter case, please log in as the numishare-admin
+                role and create a new collection for the associated Tomcat role.</p>
+            </xforms:case>
+            <xforms:case id="numishare-admin">
+              <div id="form">
+                <xforms:group ref=".[count(distinct-values(instance('collections-list')/collection/@name)) != count(instance('collections-list')/collection/@name)]">
+                  <div class="alert alert-box alert-danger">
+                    <span class="glyphicon glyphicon-exclamation-sign"></span>
+                    <strong>Alert:</strong> Collection of this name already exists.</div>
+                </xforms:group>
+                <xforms:group ref=".[count(distinct-values(instance('collections-list')/collection/@role)) != count(instance('collections-list')/collection/@role)]">
+                  <div class="alert alert-box alert-warning">
+                    <span class="glyphicon glyphicon-exclamation-sign"></span>
+                    <strong>Alert:</strong>A role cannot be bound to more than one collection.</div>
+                </xforms:group>
+                <xforms:group ref=".[instance('control-instance')/status/text()]">
+                  <div class="alert alert-box alert-success">
+                    <p><span class="glyphicon glyphicon-info-sign"></span>
+                      <strong>Status:</strong>
+                      <xforms:output ref="instance('control-instance')/status" />
+                    </p>
+                  </div>
+                </xforms:group>
+                <h2>Numishare Administration</h2>
                 <xforms:switch>
-                    <xforms:case id="unauthorized-user">
-                        <h2>Unauthorized User</h2>
-                        <p>You are seeing this interface either because authentication has not been enabled for the Numishare administrative panel or there is no matching eXist-db collection for your role. If it is the latter case, please log in as the numishare-admin
-                            role and create a new collection for the associated Tomcat role.</p>
-                    </xforms:case>
-                    <xforms:case id="numishare-admin">
-                        <div id="form">
-                            <xforms:group ref=".[count(distinct-values(instance('collections-list')/collection/@name)) != count(instance('collections-list')/collection/@name)]">
-                                <div class="alert alert-box alert-danger">
-                                    <span class="glyphicon glyphicon-exclamation-sign"></span>
-                                    <strong>Alert:</strong> Collection of this name already exists.</div>
-                            </xforms:group>
-                            <xforms:group ref=".[count(distinct-values(instance('collections-list')/collection/@role)) != count(instance('collections-list')/collection/@role)]">
-                                <div class="alert alert-box alert-warning">
-                                    <span class="glyphicon glyphicon-exclamation-sign"></span>
-                                    <strong>Alert:</strong>A role cannot be bound to more than one collection.</div>
-                            </xforms:group>
-                            <xforms:group ref=".[instance('control-instance')/status/text()]">
-                                <div class="alert alert-box alert-success">
-                                    <p><span class="glyphicon glyphicon-info-sign"></span>
-                                        <strong>Status:</strong>
-                                        <xforms:output ref="instance('control-instance')/status" />
-                                    </p>
-                                </div>
-                            </xforms:group>
-                            <h2>Numishare Administration</h2>
-                            <xforms:switch>
-                                <xforms:case id="collections-list-interface">
-                                    <div>
-                                        <xforms:group ref=".[count(instance('collections-list')/collection) &gt; 0]">
-                                            <xforms:group ref="instance('collections-list')">
-                                                <h3>Collections List<small><xforms:trigger appearance="minimal"><xforms:label><span
-																		class="glyphicon glyphicon-plus"></span>Add collection</xforms:label><xforms:action
-																	ev:event="DOMActivate">
-																	<xforms:insert context="instance('collections-list')" nodeset="./child::node()[last()]"
-																		origin="xforms:element('collection', (xforms:attribute('name', ''), xforms:attribute('role', '')))"/>
-																	<xforms:toggle case="add-collection-interface"/>
-																</xforms:action></xforms:trigger></small></h3>
-                                                <table class="table">
-                                                    <thead>
-                                                        <tr>
-                                                            <th>Collection</th>
-                                                            <th>Role</th>
-                                                            <th>Title</th>
-                                                            <th style="width:50%">Description</th>
-                                                            <th>Actions</th>
-                                                        </tr>
-                                                    </thead>
-                                                    <tbody>
-                                                        <xforms:repeat nodeset="collection">
-                                                            <xforms:var name="name" select="@name" />
-                                                            <tr>
-                                                                <td>
-                                                                    <xforms:output ref="$name" />
-                                                                </td>
-                                                                <td>
-                                                                    <xforms:output ref="@role" />
-                                                                </td>
-                                                                <td>
-                                                                    <xforms:trigger appearance="minimal">
-                                                                        <xforms:label value="instance('xquery-result')//collection[@id=$name]/title" />
-                                                                        <xforms:load ev:event="DOMActivate" ref=" instance('xquery-result')//collection[@id=$name]/url" show="new" />
-                                                                    </xforms:trigger>
-                                                                </td>
-                                                                <td>
-                                                                    <xforms:output ref="instance('xquery-result')//collection[@id=$name]/description" />
-                                                                </td>
-                                                                <td>
-                                                                    <xforms:trigger appearance="minimal">
-                                                                        <xforms:label><span class="glyphicon glyphicon-pencil"></span></xforms:label>
-                                                                        <xforms:hint>Edit Collection</xforms:hint>
-                                                                        <xforms:action ev:event="DOMActivate">
-                                                                            <!-- set session attribute of the selected collection name -->
-                                                                            <xforms:setvalue ref="instance('control-instance')/collection-name" value="$name" />
-                                                                            <xforms:insert context="." origin="xxforms:set-session-attribute('collection-name', instance('control-instance')/collection-name)" />
-                                                                            <!-- load the associated config and display the Numishare editor interface -->
-                                                                            <xforms:send submission="load-config" />
-                                                                            <xforms:toggle case="numishare-editor" />
-                                                                        </xforms:action>
-                                                                    </xforms:trigger>
-                                                                    <xforms:trigger appearance="minimal">
-                                                                        <xforms:label><span class="glyphicon glyphicon-trash"></span></xforms:label>
-                                                                        <xforms:hint>Delete Collection</xforms:hint>
-                                                                        <xforms:action ev:event="DOMActivate">
-                                                                            <xforms:setvalue ref="instance('control-instance')/collection-name" value="$name" />
-                                                                            <xforms:dispatch target="delete-collection-dialog" name="fr-show" />
-                                                                        </xforms:action>
-                                                                    </xforms:trigger>
-                                                                </td>
-                                                            </tr>
-                                                        </xforms:repeat>
-                                                    </tbody>
-                                                </table>
-                                            </xforms:group>
-                                        </xforms:group>
-                                        <xforms:group ref=".[count(instance('collections-list')/collection) = 0]">
-                                            <p>There are no collections in Numishare.
-                                                <xforms:trigger appearance="minimal">
-                                                    <xforms:label><span class="glyphicon glyphicon-plus"></span>Add one.</xforms:label>
-                                                    <xforms:action ev:event="DOMActivate">
-                                                        <xforms:insert context="instance('collections-list')" nodeset="./child::node()[last()]" origin="xforms:element('collection', (xforms:attribute('name', ''), xforms:attribute('role', '')))" />
-                                                        <xforms:toggle case="add-collection-interface" />
-                                                    </xforms:action>
-                                                </xforms:trigger>
-                                            </p>
-                                        </xforms:group>
-                                    </div>
-                                </xforms:case>
-                                <xforms:case id="add-collection-interface">
-                                    <div>
-                                        <h3>Add New Collection</h3>
-                                        <div>
-                                            <xforms:group ref="instance('collections-list')/collection[last()]">
-                                                <div>
-                                                    <xforms:input ref="@role">
-                                                        <xforms:label>Tomcat Role</xforms:label>
-                                                        <xforms:alert>Must conform to xs:ID</xforms:alert>
-                                                    </xforms:input>
-                                                </div>
-                                                <div>
-                                                    <xforms:input ref="@name">
-                                                        <xforms:label>Collection Name</xforms:label>
-                                                        <xforms:alert>Must conform to xs:ID</xforms:alert>
-                                                        <xforms:action ev:event="xforms-value-changed">
-                                                            <xforms:var name="name" select="." />
-                                                            <xforms:setvalue ref="instance('config-template')/url" value="concat('http://localhost:8080/orbeon/numishare/', $name, '/')" />
-                                                            <xforms:setvalue ref="instance('config-template')/uri_space" value="concat('http://localhost:8080/orbeon/numishare/', $name, '/id/')" />
-                                                        </xforms:action>
-                                                    </xforms:input>
-                                                </div>
-                                            </xforms:group>
-                                            <xforms:group ref="instance('config-template')">
-                                                <div>
-                                                    <xforms:input ref="installation_path">
-                                                        <xforms:label>Installation Directory</xforms:label>
-                                                        <xforms:alert>Required</xforms:alert>
-                                                    </xforms:input>
-                                                    <p class="text-muted">The absolute path to the directory to which Numishare was installed. This is necessary for writing XQuery files from the disk into the eXist-db collection.</p>
-                                                </div>
-                                                <h4>Boilerplate</h4>
-                                                <div>
-                                                    <xforms:input ref="title">
-                                                        <xforms:label>Collection Title</xforms:label>
-                                                        <xforms:alert>Required</xforms:alert>
-                                                    </xforms:input>
-                                                </div>
-                                                <div>
-                                                    <xforms:input ref="description">
-                                                        <xforms:label>Description</xforms:label>
-                                                        <xforms:alert>Required</xforms:alert>
-                                                    </xforms:input>
-                                                </div>
-                                                <div>
-                                                    <xforms:select1 ref="collection_type">
-                                                        <xforms:label>Collection Type</xforms:label>
-                                                        <xforms:item>
-                                                            <xforms:label>Object</xforms:label>
-                                                            <xforms:value>object</xforms:value>
-                                                        </xforms:item>
-                                                        <xforms:item>
-                                                            <xforms:label>Coin Type</xforms:label>
-                                                            <xforms:value>cointype</xforms:value>
-                                                        </xforms:item>
-                                                        <xforms:item>
-                                                            <xforms:label>Hoard</xforms:label>
-                                                            <xforms:value>hoard</xforms:value>
-                                                        </xforms:item>
-                                                        <xforms:alert>Required</xforms:alert>
-                                                    </xforms:select1>
-                                                </div>
-                                                <div>
-                                                    <xforms:input ref="template/agencyName">
-                                                        <xforms:label>Maintainer</xforms:label>
-                                                        <xforms:alert>Required</xforms:alert>
-                                                        <xforms:hint>The agent responsible for maintaining the data.</xforms:hint>
-                                                    </xforms:input>
-                                                </div>
-                                                <div>
-                                                    <xforms:select1 ref="template/language">
-                                                        <xforms:label>Default Language</xforms:label>
-                                                        <xforms:item>
-                                                            <xforms:label>Select Language...</xforms:label>
-                                                            <xforms:value/>
-                                                        </xforms:item>
-                                                        <xforms:itemset nodeset="instance('languages')//language">
-                                                            <xforms:label ref="." />
-                                                            <xforms:value ref="@value" />
-                                                        </xforms:itemset>
-                                                        <xforms:alert>Required</xforms:alert>
-                                                    </xforms:select1>
-                                                </div>
-                                                <div>
-                                                    <xforms:select1 ref="template/rights">
-                                                        <xforms:label>Rights Statement</xforms:label>
-                                                        <xforms:alert>Required</xforms:alert>
-                                                        <xforms:item>
-                                                            <xforms:label>Select License...</xforms:label>
-                                                            <xforms:value/>
-                                                        </xforms:item>
-                                                        <xforms:itemset nodeset="instance('rights-list')/statement">
-                                                            <xforms:label ref="." />
-                                                            <xforms:value ref="@value" />
-                                                        </xforms:itemset>
-                                                    </xforms:select1>
-                                                </div>
-                                                <div>
-                                                    <xforms:select1 ref="template/license[@for='images']">
-                                                        <xforms:label>Image License</xforms:label>
-                                                        <xforms:alert>Required</xforms:alert>
-                                                        <xforms:item>
-                                                            <xforms:label>Select License...</xforms:label>
-                                                            <xforms:value/>
-                                                        </xforms:item>
-                                                        <xforms:itemset nodeset="instance('license-list')/images/statement">
-                                                            <xforms:label ref="." />
-                                                            <xforms:value ref="@value" />
-                                                        </xforms:itemset>
-                                                    </xforms:select1>
-                                                </div>
-                                                <div>
-                                                    <xforms:select1 ref="template/license[@for='data']">
-                                                        <xforms:label>Data License</xforms:label>
-                                                        <xforms:alert>Required</xforms:alert>
-                                                        <xforms:item>
-                                                            <xforms:label>Select License...</xforms:label>
-                                                            <xforms:value/>
-                                                        </xforms:item>
-                                                        <xforms:itemset nodeset="instance('license-list')/data/statement">
-                                                            <xforms:label ref="." />
-                                                            <xforms:value ref="@value" />
-                                                        </xforms:itemset>
-                                                    </xforms:select1>
-                                                </div>
-                                                <h4>URLS</h4>
-                                                <div>
-                                                    <xforms:input ref="url">
-                                                        <xforms:label>Public Site</xforms:label>
-                                                        <xforms:alert>Required, must be a URL</xforms:alert>
-                                                        <xforms:action ev:event="xforms-value-changed">
-                                                            <xforms:var name="uri" select="." />
-                                                            <xforms:setvalue ref="instance('config-template')/uri_space" value="concat($uri, 'id/')" />
-                                                        </xforms:action>
-                                                    </xforms:input>
-                                                </div>
-                                                <div>
-                                                    <xforms:input ref="solr_published">
-                                                        <xforms:label>Solr Published</xforms:label>
-                                                        <xforms:alert>Required, must be a URL</xforms:alert>
-                                                        <xforms:hint>Unlikely to need changing.</xforms:hint>
-                                                    </xforms:input>
-                                                </div>
-                                            </xforms:group>
-                                            <xforms:trigger>
-                                                <xforms:label>Cancel</xforms:label>
-                                                <xforms:action ev:event="DOMActivate">
-                                                    <xforms:delete nodeset="instance('collections-list')/collection[last()]" />
-                                                    <xforms:toggle case="collections-list-interface" />
-                                                </xforms:action>
-                                            </xforms:trigger>
-                                            <xforms:trigger bind="create-collection-trigger">
-                                                <xforms:label>Create</xforms:label>
-                                                <xforms:action ev:event="DOMActivate">
-                                                    <!-- save collections list, config, and XQL files -->
-                                                    <xforms:send submission="save-collections" />
-                                                    <xforms:action ev:event="xforms-submit-done">
-                                                        <xforms:setvalue ref="instance('control-instance')/status">Collection successfully created in eXist-db.
-                                                        </xforms:setvalue>
-                                                        <xforms:setvalue ref="instance('control-instance')/collection-name" value="instance('collections-list')/collection[last()]/@name" />
-                                                        <xforms:send submission="save-config" />
-                                                    </xforms:action>
-                                                    <xforms:toggle case="collections-list-interface" />
-                                                </xforms:action>
-                                            </xforms:trigger>
-                                        </div>
-                                    </div>
-                                </xforms:case>
-                            </xforms:switch>
-                        </div>
-                    </xforms:case>
-                    <xforms:case id="numishare-editor">
-                        <div id="form">
-
-                            <xforms:group ref=".[xxforms:is-user-in-role('numishare-admin')]">
-                                <div>
+                  <xforms:case id="collections-list-interface">
+                    <div>
+                      <xforms:group ref=".[count(instance('collections-list')/collection) &gt; 0]">
+                        <xforms:group ref="instance('collections-list')">
+                          <h3>Collections List<small><xforms:trigger appearance="minimal"><xforms:label><span
+													   class="glyphicon glyphicon-plus"></span>Add collection</xforms:label><xforms:action
+																						   ev:event="DOMActivate">
+				  <xforms:insert context="instance('collections-list')" nodeset="./child::node()[last()]"
+						 origin="xforms:element('collection', (xforms:attribute('name', ''), xforms:attribute('role', '')))"/>
+				  <xforms:toggle case="add-collection-interface"/>
+			  </xforms:action></xforms:trigger></small></h3>
+                          <table class="table">
+                            <thead>
+                              <tr>
+                                <th>Collection</th>
+                                <th>Role</th>
+                                <th>Title</th>
+                                <th style="width:50%">Description</th>
+                                <th>Actions</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              <xforms:repeat nodeset="collection">
+                                <xforms:var name="name" select="@name" />
+                                <tr>
+                                  <td>
+                                    <xforms:output ref="$name" />
+                                  </td>
+                                  <td>
+                                    <xforms:output ref="@role" />
+                                  </td>
+                                  <td>
                                     <xforms:trigger appearance="minimal">
-                                        <xforms:label><span class="glyphicon glyphicon-arrow-left"></span> Return to Collections List</xforms:label>
-                                        <xforms:action ev:event="DOMActivate">
-                                            <!-- clear session attributes -->
-                                            <xforms:setvalue ref="instance('control-instance')/collection-name" />
-                                            <xforms:insert context="." origin="xxforms:set-session-attribute('collection-name', '')" />
-                                            <!-- get collection metadata -->
-                                            <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='collection-metadata'], '%SEQUENCE%', string-join(instance('collections-list')/collection/@name, ','))" />
-                                            <xforms:send submission="xquery-db" />
-                                            <xforms:action ev:event="xforms-submit-done">
-                                                <xforms:toggle case="numishare-admin" />
-                                            </xforms:action>
-                                        </xforms:action>
+                                      <xforms:label value="instance('xquery-result')//collection[@id=$name]/title" />
+                                      <xforms:load ev:event="DOMActivate" ref=" instance('xquery-result')//collection[@id=$name]/url" show="new" />
                                     </xforms:trigger>
-                                </div>
-                            </xforms:group>
-                            <xforms:group ref=".[instance('control-instance')/status/text()]">
-                                <div class="alert alert-box alert-success">
-                                    <p><span class="glyphicon glyphicon-info-sign"></span>
-                                        <strong>Status:</strong>
-                                        <xforms:output ref="instance('control-instance')/status" />
-                                    </p>
-                                </div>
-                            </xforms:group>
-
-                            <xforms:switch>
-                                <xforms:case id="collection-interface">
-                                    <h2>Object Management</h2>
-                                    <ul>
-                                        <li>
-                                            <a href="edit/coin/">Create New Coin or Medal</a>
-                                        </li>
-                                        <!--<li>
-										<a href="edit/object/">Create New Non-Coin Object</a>
-									</li>-->
-                                    </ul>
-                                    <h2>Publication</h2>
-                                    <ul>
-                                        <li>
-                                            <xforms:trigger appearance="minimal">
-                                                <xforms:label>Put them in 3store</xforms:label>
-                                                <xforms:dispatch target="publish-3store-dialog" name="fr-show" ev:event="DOMActivate" />
-                                            </xforms:trigger>
-                                        </li>
-                                        <li>
-                                            <xforms:trigger appearance="minimal">
-                                                <xforms:label>Publish All Approved Objects</xforms:label>
-                                                <xforms:dispatch target="publish-all-dialog" name="fr-show" ev:event="DOMActivate" />
-                                            </xforms:trigger>
-                                        </li>
-                                        <li>
-                                            <xforms:trigger appearance="minimal">
-                                                <xforms:label>Reindex Published Objects</xforms:label>
-                                                <xforms:dispatch target="republish-dialog" name="fr-show" ev:event="DOMActivate" />
-                                            </xforms:trigger>
-                                        </li>
-                                        <li>
-                                            <xforms:trigger appearance="minimal">
-                                                <xforms:label>Unpublish All Objects</xforms:label>
-                                                <xforms:dispatch target="unpublish-all" name="fr-show" ev:event="DOMActivate" />
-                                            </xforms:trigger>
-                                        </li>
-                                    </ul>
-                                    <!-- search -->
-                                    <xforms:group ref="instance('control-instance')[number(numFound) &gt; 0]">
-                                        <div>
-                                            <h3>Search</h3>
-                                            <xforms:input ref="query_input" />
-                                            <xforms:trigger>
-                                                <xforms:label>Search</xforms:label>
-                                                <xforms:action ev:event="DOMActivate">
-                                                    <xforms:setvalue ref="instance('control-instance')/query_sent" value="instance('control-instance')/query_input" />
-                                                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='query-objects'], 'QUERY', instance('control-instance')/query_sent)" />
-                                                    <xforms:send submission="xquery-pagination" />
-                                                </xforms:action>
-                                            </xforms:trigger>
-                                            <xforms:group ref=".[string(query_sent)]">
-                                                <xforms:trigger>
-                                                    <xforms:label>Clear</xforms:label>
-                                                    <xforms:action ev:event="DOMActivate">
-                                                        <!-- clear queries-->
-                                                        <xforms:setvalue ref="instance('control-instance')/query_input" />
-                                                        <xforms:setvalue ref="instance('control-instance')/query_sent" />
-                                                        <!-- re-establish pagination query on page 1 -->
-                                                        <xforms:setvalue ref="instance('control-instance')/page" value="1" />
-                                                        <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')" />
-                                                        <xforms:send submission="xquery-pagination" />
-                                                    </xforms:action>
-                                                </xforms:trigger>
-                                            </xforms:group>
-                                        </div>
-                                    </xforms:group>
-                                    <xforms:group ref="instance('pagination-result')">
-                                        <xforms:group ref=".[count(//record) &gt; 0]">
-                                            <h3>List of Objects</h3>
-                                            <!-- pagination variables -->
-                                            <xforms:var name="numFound" select="number(instance('control-instance')/numFound)" />
-                                            <xforms:var name="page" select="number(instance('control-instance')/page)" />
-                                            <xforms:var name="current" select="$page" />
-                                            <xforms:var name="rows" select="number(20)" />
-                                            <xforms:var name="start" select="(($page - 1) * 20) + 1" />
-                                            <xforms:var name="end" select="if ($numFound &lt; $page * 20) then $numFound else $page * 20" />
-                                            <xforms:var name="next" select="($page * 20) + 1" />
-                                            <xforms:var name="total" select="ceiling($numFound div 20)" />
-                                            <!-- pagination -->
-                                            <xforms:group ref=".[string-length(instance('control-instance')/query_sent) = 0]">
-                                                <!-- pagination -->
-                                                <div class="paging_div row">
-                                                    <div class="col-md-6"> Displaying records <b>
-																<xforms:output value="(($page - 1) * $rows) + 1"/>
-															</b> to <b>
-																<xforms:output value="if ($numFound &gt; $page * $rows) then $page * $rows else $numFound"/>
-															</b> of <b>
-																<xforms:output value="$numFound"/>
-															</b> total results.</div>
-                                                    <div class="col-md-6 text-right">
-                                                        <!-- previous -->
-                                                        <xforms:group ref=".[$page &gt; 1]">
-                                                            <xforms:trigger>
-                                                                <xforms:label><span class="glyphicon glyphicon-fast-backward"></span></xforms:label>
-                                                                <xforms:action ev:event="DOMActivate">
-                                                                    <xforms:setvalue ref="instance('control-instance')/page" value="1" />
-                                                                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')" />
-                                                                    <xforms:send submission="xquery-pagination" />
-                                                                </xforms:action>
-                                                            </xforms:trigger>
-                                                            <xforms:trigger>
-                                                                <xforms:label><span class="glyphicon glyphicon-backward"></span></xforms:label>
-                                                                <xforms:action ev:event="DOMActivate">
-                                                                    <xforms:setvalue ref="instance('control-instance')/page" value="$page - 1" />
-                                                                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', string($start - 20))" />
-                                                                    <xforms:send submission="xquery-pagination" />
-                                                                </xforms:action>
-                                                            </xforms:trigger>
-                                                        </xforms:group>
-                                                        <xforms:group ref=".[$page = 1]">
-                                                            <a class="btn btn-default disabled" title="First" href="#">
-                                                                <span class="glyphicon glyphicon-fast-backward"></span>
-                                                            </a>
-                                                            <a class="btn btn-default disabled" title="Previous" href="#">
-                                                                <span class="glyphicon glyphicon-backward"></span>
-                                                            </a>
-                                                        </xforms:group>
-                                                        <!-- current-->
-                                                        <button type="button" class="btn btn-default">
-																<b>
-																	<xforms:output value="$current"/>
-																</b>
-															</button>
-                                                        <!-- next -->
-                                                        <xforms:group ref=".[$total &gt; $current]">
-                                                            <xforms:trigger>
-                                                                <xforms:label><span class="glyphicon glyphicon-forward"></span></xforms:label>
-                                                                <xforms:action ev:event="DOMActivate">
-                                                                    <xforms:setvalue ref="instance('control-instance')/page" value="$page + 1" />
-                                                                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', string($next))" />
-                                                                    <xforms:send submission="xquery-pagination" />
-                                                                </xforms:action>
-                                                            </xforms:trigger>
-                                                            <xforms:trigger>
-                                                                <xforms:label>
-                                                                    <span class="glyphicon glyphicon-fast-forward"></span>
-                                                                </xforms:label>
-                                                                <xforms:action ev:event="DOMActivate">
-                                                                    <xforms:setvalue ref="instance('control-instance')/page" value="$total" />
-                                                                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', string((($total - 1) * 20) + 1))" />
-                                                                    <xforms:send submission="xquery-pagination" />
-                                                                </xforms:action>
-                                                            </xforms:trigger>
-                                                        </xforms:group>
-                                                        <xforms:group ref=".[not($total &gt; $current)]">
-                                                            <a class="btn btn-default disabled" title="Next" href="#">
-                                                                <span class="glyphicon glyphicon-forward"></span>
-                                                            </a>
-                                                            <a class="btn btn-default disabled" href="#">
-                                                                <span class="glyphicon glyphicon-fast-forward"></span>
-                                                            </a>
-                                                        </xforms:group>
-                                                    </div>
-                                                </div>
-                                            </xforms:group>
-                                            <table class="table">
-                                                <thead>
-                                                    <tr>
-                                                        <th style="width:5%">Type</th>
-                                                        <th>Title</th>
-                                                        <th style="width:10%">View</th>
-                                                        <th style="width:5%">Publish</th>
-                                                        <th style="width:5%">Delete</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    <xforms:repeat nodeset="instance('pagination-result')//record">
-                                                        <xforms:var name="id" select="id" />
-                                                        <tr>
-                                                            <td class="text-center">
-                                                                <xforms:output ref="type" />
-                                                            </td>
-                                                            <td>
-                                                                <h4>
-                                                                    <xforms:group ref=".[type='nuds']">
-                                                                        <xforms:trigger appearance="minimal">
-                                                                            <xforms:label value="concat(title, ' (', $id, ')')" />
-                                                                            <xforms:action ev:event="DOMActivate">
-                                                                                <xforms:load show="replace" resource="edit/coin/?id={$id}" />
-                                                                            </xforms:action>
-                                                                        </xforms:trigger>
-                                                                    </xforms:group>
-                                                                    <xforms:group ref=".[type!='nuds']">
-                                                                        <xforms:output ref="title" />
-                                                                        <xforms:output ref="concat('(', $id, ')')" />
-                                                                    </xforms:group>
-                                                                </h4>
-                                                                <div>
-                                                                    <xforms:output ref="maintenanceStatus">
-                                                                        <xforms:label>Status</xforms:label>
-                                                                    </xforms:output>
-                                                                </div>
-                                                                <xforms:group ref="recordType">
-                                                                    <div>
-                                                                        <xforms:output ref=".">
-                                                                            <xforms:label>Record Type</xforms:label>
-                                                                        </xforms:output>
-                                                                    </div>
-                                                                </xforms:group>
-                                                                <xforms:group ref="obverse">
-                                                                    <div>
-                                                                        <xforms:output ref=".">
-                                                                            <xforms:label>Obverse</xforms:label>
-                                                                        </xforms:output>
-                                                                    </div>
-                                                                </xforms:group>
-                                                                <xforms:group ref="reverse">
-                                                                    <div>
-                                                                        <xforms:output ref=".">
-                                                                            <xforms:label>Reverse</xforms:label>
-                                                                        </xforms:output>
-                                                                    </div>
-                                                                </xforms:group>
-                                                            </td>
-                                                            <td class="text-center">
-                                                                <a href="{instance('config')/url}id/{$id}.xml" target="_blank">xml</a> | <a href="{instance('config')/url}id/{$id}" target="_blank">html</a>
-                                                            </td>
-                                                            <td class="text-center">
-                                                                <!-- only enable publication if the maintenanceStatus allows it -->
-                                                                <xforms:group ref=".[maintenanceStatus='new' or maintenanceStatus='revised' or maintenanceStatus='derived']">
-                                                                    <xforms:group ref="published[. = true()]">
-                                                                        <xforms:trigger appearance="minimal">
-                                                                            <xforms:label><span class="glyphicon glyphicon-{if (.=true()) then 'ok' else 'unchecked'}"></span></xforms:label>
-                                                                            <xforms:action ev:event="DOMActivate">
-                                                                                <xforms:var name="val" select="." as="xs:boolean" />
-                                                                                <xforms:setvalue ref="instance('control-instance')/id" value="$id" />
-                                                                                <!-- update publicationStatus -->
-                                                                                <xforms:setvalue ref="instance('control-instance')/publicationStatus">inProcess</xforms:setvalue>
-                                                                                <xforms:send submission="load-object" />
-                                                                                <!-- delete from Solr -->
-                                                                                <xforms:setvalue ref="instance('deleteId')/query" value="concat('recordId:&#x022;', instance('control-instance')/id, '&#x022;')" />
-                                                                                <xforms:send submission="delete-solr-doc" />
-                                                                                <xforms:setvalue ref="." value="false()" />
-                                                                            </xforms:action>
-                                                                        </xforms:trigger>
-                                                                    </xforms:group>
-                                                                    <xforms:group ref="published[. = false()]">
-                                                                        <xforms:trigger appearance="minimal">
-                                                                            <xforms:label><span class="glyphicon glyphicon-{if (.=true()) then 'ok' else 'unchecked'}"></span></xforms:label>
-                                                                            <xforms:action ev:event="DOMActivate">
-                                                                                <xforms:var name="val" select="." as="xs:boolean" />
-                                                                                <!-- publish the record if the box is checked -->
-                                                                                <xforms:setvalue ref="instance('control-instance')/id" value="$id" />
-                                                                                <xforms:setvalue ref="instance('control-instance')/publicationStatus">approved</xforms:setvalue>
-                                                                                <xforms:send submission="load-object" />
-                                                                                <!-- publish to solr -->
-                                                                                <xforms:send submission="nuds-to-solr" />
-                                                                                <xforms:send submission="submit-commit" />
-                                                                                <xforms:setvalue ref="." value="true()" />
-                                                                            </xforms:action>
-                                                                        </xforms:trigger>
-                                                                    </xforms:group>
-                                                                </xforms:group>
-                                                            </td>
-                                                            <td class="text-center">
-                                                                <xforms:trigger appearance="minimal">
-                                                                    <xforms:label>
-                                                                        <span class="glyphicon glyphicon-remove"></span>
-                                                                    </xforms:label>
-                                                                    <xforms:action ev:event="DOMActivate">
-                                                                        <xforms:setvalue ref="instance('control-instance')/id" value="$id" />
-                                                                        <xforms:dispatch target="delete" name="fr-show" />
-                                                                    </xforms:action>
-                                                                </xforms:trigger>
-                                                            </td>
-                                                        </tr>
-                                                    </xforms:repeat>
-                                                </tbody>
-                                            </table>
-                                        </xforms:group>
-                                        <xforms:group ref=".[count(//record)=0]">
-                                            <h3>No objects in collection.</h3>
-                                        </xforms:group>
-                                    </xforms:group>
-                                </xforms:case>
-                                <xforms:case id="union_type_catalog">
-                                    <h2>Union Type Corpus</h2>
-                                    <p>This collection is configured as a union type corpus of the following type series:</p>
-                                    <p>The XML collection is not designed to store its own NUDS documents, but rather combines Solr and SPARQL queries from the designated series in the Numishare config, pointing search/browse responses to the external corpus.</p>
-                                </xforms:case>
-                            </xforms:switch>
-                        </div>
-                    </xforms:case>
+                                  </td>
+                                  <td>
+                                    <xforms:output ref="instance('xquery-result')//collection[@id=$name]/description" />
+                                  </td>
+                                  <td>
+                                    <xforms:trigger appearance="minimal">
+                                      <xforms:label><span class="glyphicon glyphicon-pencil"></span></xforms:label>
+                                      <xforms:hint>Edit Collection</xforms:hint>
+                                      <xforms:action ev:event="DOMActivate">
+                                        <!-- set session attribute of the selected collection name -->
+                                        <xforms:setvalue ref="instance('control-instance')/collection-name" value="$name" />
+                                        <xforms:insert context="." origin="xxforms:set-session-attribute('collection-name', instance('control-instance')/collection-name)" />
+                                        <!-- load the associated config and display the Numishare editor interface -->
+                                        <xforms:send submission="load-config" />
+                                        <xforms:toggle case="numishare-editor" />
+                                      </xforms:action>
+                                    </xforms:trigger>
+                                    <xforms:trigger appearance="minimal">
+                                      <xforms:label><span class="glyphicon glyphicon-trash"></span></xforms:label>
+                                      <xforms:hint>Delete Collection</xforms:hint>
+                                      <xforms:action ev:event="DOMActivate">
+                                        <xforms:setvalue ref="instance('control-instance')/collection-name" value="$name" />
+                                        <xforms:dispatch target="delete-collection-dialog" name="fr-show" />
+                                      </xforms:action>
+                                    </xforms:trigger>
+                                  </td>
+                                </tr>
+                              </xforms:repeat>
+                            </tbody>
+                          </table>
+                        </xforms:group>
+                      </xforms:group>
+                      <xforms:group ref=".[count(instance('collections-list')/collection) = 0]">
+                        <p>There are no collections in Numishare.
+                          <xforms:trigger appearance="minimal">
+                            <xforms:label><span class="glyphicon glyphicon-plus"></span>Add one.</xforms:label>
+                            <xforms:action ev:event="DOMActivate">
+                              <xforms:insert context="instance('collections-list')" nodeset="./child::node()[last()]" origin="xforms:element('collection', (xforms:attribute('name', ''), xforms:attribute('role', '')))" />
+                              <xforms:toggle case="add-collection-interface" />
+                            </xforms:action>
+                          </xforms:trigger>
+                        </p>
+                      </xforms:group>
+                    </div>
+                  </xforms:case>
+                  <xforms:case id="add-collection-interface">
+                    <div>
+                      <h3>Add New Collection</h3>
+                      <div>
+                        <xforms:group ref="instance('collections-list')/collection[last()]">
+                          <div>
+                            <xforms:input ref="@role">
+                              <xforms:label>Tomcat Role</xforms:label>
+                              <xforms:alert>Must conform to xs:ID</xforms:alert>
+                            </xforms:input>
+                          </div>
+                          <div>
+                            <xforms:input ref="@name">
+                              <xforms:label>Collection Name</xforms:label>
+                              <xforms:alert>Must conform to xs:ID</xforms:alert>
+                              <xforms:action ev:event="xforms-value-changed">
+                                <xforms:var name="name" select="." />
+                                <xforms:setvalue ref="instance('config-template')/url" value="concat('http://localhost:8080/orbeon/numishare/', $name, '/')" />
+                                <xforms:setvalue ref="instance('config-template')/uri_space" value="concat('http://localhost:8080/orbeon/numishare/', $name, '/id/')" />
+                              </xforms:action>
+                            </xforms:input>
+                          </div>
+                        </xforms:group>
+                        <xforms:group ref="instance('config-template')">
+                          <div>
+                            <xforms:input ref="installation_path">
+                              <xforms:label>Installation Directory</xforms:label>
+                              <xforms:alert>Required</xforms:alert>
+                            </xforms:input>
+                            <p class="text-muted">The absolute path to the directory to which Numishare was installed. This is necessary for writing XQuery files from the disk into the eXist-db collection.</p>
+                          </div>
+                          <h4>Boilerplate</h4>
+                          <div>
+                            <xforms:input ref="title">
+                              <xforms:label>Collection Title</xforms:label>
+                              <xforms:alert>Required</xforms:alert>
+                            </xforms:input>
+                          </div>
+                          <div>
+                            <xforms:input ref="description">
+                              <xforms:label>Description</xforms:label>
+                              <xforms:alert>Required</xforms:alert>
+                            </xforms:input>
+                          </div>
+                          <div>
+                            <xforms:select1 ref="collection_type">
+                              <xforms:label>Collection Type</xforms:label>
+                              <xforms:item>
+                                <xforms:label>Object</xforms:label>
+                                <xforms:value>object</xforms:value>
+                              </xforms:item>
+                              <xforms:item>
+                                <xforms:label>Coin Type</xforms:label>
+                                <xforms:value>cointype</xforms:value>
+                              </xforms:item>
+                              <xforms:item>
+                                <xforms:label>Hoard</xforms:label>
+                                <xforms:value>hoard</xforms:value>
+                              </xforms:item>
+                              <xforms:alert>Required</xforms:alert>
+                            </xforms:select1>
+                          </div>
+                          <div>
+                            <xforms:input ref="template/agencyName">
+                              <xforms:label>Maintainer</xforms:label>
+                              <xforms:alert>Required</xforms:alert>
+                              <xforms:hint>The agent responsible for maintaining the data.</xforms:hint>
+                            </xforms:input>
+                          </div>
+                          <div>
+                            <xforms:select1 ref="template/language">
+                              <xforms:label>Default Language</xforms:label>
+                              <xforms:item>
+                                <xforms:label>Select Language...</xforms:label>
+                                <xforms:value/>
+                              </xforms:item>
+                              <xforms:itemset nodeset="instance('languages')//language">
+                                <xforms:label ref="." />
+                                <xforms:value ref="@value" />
+                              </xforms:itemset>
+                              <xforms:alert>Required</xforms:alert>
+                            </xforms:select1>
+                          </div>
+                          <div>
+                            <xforms:select1 ref="template/rights">
+                              <xforms:label>Rights Statement</xforms:label>
+                              <xforms:alert>Required</xforms:alert>
+                              <xforms:item>
+                                <xforms:label>Select License...</xforms:label>
+                                <xforms:value/>
+                              </xforms:item>
+                              <xforms:itemset nodeset="instance('rights-list')/statement">
+                                <xforms:label ref="." />
+                                <xforms:value ref="@value" />
+                              </xforms:itemset>
+                            </xforms:select1>
+                          </div>
+                          <div>
+                            <xforms:select1 ref="template/license[@for='images']">
+                              <xforms:label>Image License</xforms:label>
+                              <xforms:alert>Required</xforms:alert>
+                              <xforms:item>
+                                <xforms:label>Select License...</xforms:label>
+                                <xforms:value/>
+                              </xforms:item>
+                              <xforms:itemset nodeset="instance('license-list')/images/statement">
+                                <xforms:label ref="." />
+                                <xforms:value ref="@value" />
+                              </xforms:itemset>
+                            </xforms:select1>
+                          </div>
+                          <div>
+                            <xforms:select1 ref="template/license[@for='data']">
+                              <xforms:label>Data License</xforms:label>
+                              <xforms:alert>Required</xforms:alert>
+                              <xforms:item>
+                                <xforms:label>Select License...</xforms:label>
+                                <xforms:value/>
+                              </xforms:item>
+                              <xforms:itemset nodeset="instance('license-list')/data/statement">
+                                <xforms:label ref="." />
+                                <xforms:value ref="@value" />
+                              </xforms:itemset>
+                            </xforms:select1>
+                          </div>
+                          <h4>URLS</h4>
+                          <div>
+                            <xforms:input ref="url">
+                              <xforms:label>Public Site</xforms:label>
+                              <xforms:alert>Required, must be a URL</xforms:alert>
+                              <xforms:action ev:event="xforms-value-changed">
+                                <xforms:var name="uri" select="." />
+                                <xforms:setvalue ref="instance('config-template')/uri_space" value="concat($uri, 'id/')" />
+                              </xforms:action>
+                            </xforms:input>
+                          </div>
+                          <div>
+                            <xforms:input ref="solr_published">
+                              <xforms:label>Solr Published</xforms:label>
+                              <xforms:alert>Required, must be a URL</xforms:alert>
+                              <xforms:hint>Unlikely to need changing.</xforms:hint>
+                            </xforms:input>
+                          </div>
+                        </xforms:group>
+                        <xforms:trigger>
+                          <xforms:label>Cancel</xforms:label>
+                          <xforms:action ev:event="DOMActivate">
+                            <xforms:delete nodeset="instance('collections-list')/collection[last()]" />
+                            <xforms:toggle case="collections-list-interface" />
+                          </xforms:action>
+                        </xforms:trigger>
+                        <xforms:trigger bind="create-collection-trigger">
+                          <xforms:label>Create</xforms:label>
+                          <xforms:action ev:event="DOMActivate">
+                            <!-- save collections list, config, and XQL files -->
+                            <xforms:send submission="save-collections" />
+                            <xforms:action ev:event="xforms-submit-done">
+                              <xforms:setvalue ref="instance('control-instance')/status">Collection successfully created in eXist-db.
+                              </xforms:setvalue>
+                              <xforms:setvalue ref="instance('control-instance')/collection-name" value="instance('collections-list')/collection[last()]/@name" />
+                              <xforms:send submission="save-config" />
+                            </xforms:action>
+                            <xforms:toggle case="collections-list-interface" />
+                          </xforms:action>
+                        </xforms:trigger>
+                      </div>
+                    </div>
+                  </xforms:case>
                 </xforms:switch>
-                <!--<fr:xforms-inspector/>-->
-            </div>
+              </div>
+            </xforms:case>
+            <xforms:case id="numishare-editor">
+              <div id="form">
+
+                <xforms:group ref=".[xxforms:is-user-in-role('numishare-admin')]">
+                  <div>
+                    <xforms:trigger appearance="minimal">
+                      <xforms:label><span class="glyphicon glyphicon-arrow-left"></span> Return to Collections List</xforms:label>
+                      <xforms:action ev:event="DOMActivate">
+                        <!-- clear session attributes -->
+                        <xforms:setvalue ref="instance('control-instance')/collection-name" />
+                        <xforms:insert context="." origin="xxforms:set-session-attribute('collection-name', '')" />
+                        <!-- get collection metadata -->
+                        <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='collection-metadata'], '%SEQUENCE%', string-join(instance('collections-list')/collection/@name, ','))" />
+                        <xforms:send submission="xquery-db" />
+                        <xforms:action ev:event="xforms-submit-done">
+                          <xforms:toggle case="numishare-admin" />
+                        </xforms:action>
+                      </xforms:action>
+                    </xforms:trigger>
+                  </div>
+                </xforms:group>
+                <xforms:group ref=".[instance('control-instance')/status/text()]">
+                  <div class="alert alert-box alert-success">
+                    <p><span class="glyphicon glyphicon-info-sign"></span>
+                      <strong>Status:</strong>
+                      <xforms:output ref="instance('control-instance')/status" />
+                    </p>
+                  </div>
+                </xforms:group>
+
+                <xforms:switch>
+                  <xforms:case id="collection-interface">
+                    <h2>Object Management</h2>
+                    <ul>
+                      <li>
+                        <a href="edit/coin/">Create New Coin or Medal</a>
+                      </li>
+                      <!--<li>
+			  <a href="edit/object/">Create New Non-Coin Object</a>
+		      </li>-->
+                    </ul>
+                    <h2>Publication</h2>
+                    <ul>
+                      <li>
+                        <xforms:trigger appearance="minimal">
+                          <xforms:label>Publish All Approved Objects to 3store</xforms:label>
+                          <xforms:dispatch target="publish-3store-dialog" name="fr-show" ev:event="DOMActivate" />
+                        </xforms:trigger>
+                      </li>
+                      <li>
+                        <xforms:trigger appearance="minimal">
+                          <xforms:label>Publish All Approved Objects</xforms:label>
+                          <xforms:dispatch target="publish-all-dialog" name="fr-show" ev:event="DOMActivate" />
+                        </xforms:trigger>
+                      </li>
+                      <li>
+                        <xforms:trigger appearance="minimal">
+                          <xforms:label>Reindex Published Objects</xforms:label>
+                          <xforms:dispatch target="republish-dialog" name="fr-show" ev:event="DOMActivate" />
+                        </xforms:trigger>
+                      </li>
+                      <li>
+                        <xforms:trigger appearance="minimal">
+                          <xforms:label>Unpublish All Objects</xforms:label>
+                          <xforms:dispatch target="unpublish-all" name="fr-show" ev:event="DOMActivate" />
+                        </xforms:trigger>
+                      </li>
+                      <li>
+                        <xforms:trigger appearance="minimal">
+                          <xforms:label>Unpublish All Objects from 3store</xforms:label>
+                          <xforms:dispatch target="unpublish-3store-dialog" name="fr-show" ev:event="DOMActivate" />
+                        </xforms:trigger>
+                      </li>
+                    </ul>
+                    <!-- search -->
+                    <xforms:group ref="instance('control-instance')[number(numFound) &gt; 0]">
+                      <div>
+                        <h3>Search</h3>
+                        <xforms:input ref="query_input" />
+                        <xforms:trigger>
+                          <xforms:label>Search</xforms:label>
+                          <xforms:action ev:event="DOMActivate">
+                            <xforms:setvalue ref="instance('control-instance')/query_sent" value="instance('control-instance')/query_input" />
+                            <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='query-objects'], 'QUERY', instance('control-instance')/query_sent)" />
+                            <xforms:send submission="xquery-pagination" />
+                          </xforms:action>
+                        </xforms:trigger>
+                        <xforms:group ref=".[string(query_sent)]">
+                          <xforms:trigger>
+                            <xforms:label>Clear</xforms:label>
+                            <xforms:action ev:event="DOMActivate">
+                              <!-- clear queries-->
+                              <xforms:setvalue ref="instance('control-instance')/query_input" />
+                              <xforms:setvalue ref="instance('control-instance')/query_sent" />
+                              <!-- re-establish pagination query on page 1 -->
+                              <xforms:setvalue ref="instance('control-instance')/page" value="1" />
+                              <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')" />
+                              <xforms:send submission="xquery-pagination" />
+                            </xforms:action>
+                          </xforms:trigger>
+                        </xforms:group>
+                      </div>
+                    </xforms:group>
+                    <xforms:group ref="instance('pagination-result')">
+                      <xforms:group ref=".[count(//record) &gt; 0]">
+                        <h3>List of Objects</h3>
+                        <!-- pagination variables -->
+                        <xforms:var name="numFound" select="number(instance('control-instance')/numFound)" />
+                        <xforms:var name="page" select="number(instance('control-instance')/page)" />
+                        <xforms:var name="current" select="$page" />
+                        <xforms:var name="rows" select="number(20)" />
+                        <xforms:var name="start" select="(($page - 1) * 20) + 1" />
+                        <xforms:var name="end" select="if ($numFound &lt; $page * 20) then $numFound else $page * 20" />
+                        <xforms:var name="next" select="($page * 20) + 1" />
+                        <xforms:var name="total" select="ceiling($numFound div 20)" />
+                        <!-- pagination -->
+                        <xforms:group ref=".[string-length(instance('control-instance')/query_sent) = 0]">
+                          <!-- pagination -->
+                          <div class="paging_div row">
+                            <div class="col-md-6"> Displaying records <b>
+				<xforms:output value="(($page - 1) * $rows) + 1"/>
+			      </b> to <b>
+				<xforms:output value="if ($numFound &gt; $page * $rows) then $page * $rows else $numFound"/>
+			      </b> of <b>
+				<xforms:output value="$numFound"/>
+			      </b> total results.</div>
+                            <div class="col-md-6 text-right">
+                              <!-- previous -->
+                              <xforms:group ref=".[$page &gt; 1]">
+                                <xforms:trigger>
+                                  <xforms:label><span class="glyphicon glyphicon-fast-backward"></span></xforms:label>
+                                  <xforms:action ev:event="DOMActivate">
+                                    <xforms:setvalue ref="instance('control-instance')/page" value="1" />
+                                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')" />
+                                    <xforms:send submission="xquery-pagination" />
+                                  </xforms:action>
+                                </xforms:trigger>
+                                <xforms:trigger>
+                                  <xforms:label><span class="glyphicon glyphicon-backward"></span></xforms:label>
+                                  <xforms:action ev:event="DOMActivate">
+                                    <xforms:setvalue ref="instance('control-instance')/page" value="$page - 1" />
+                                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', string($start - 20))" />
+                                    <xforms:send submission="xquery-pagination" />
+                                  </xforms:action>
+                                </xforms:trigger>
+                              </xforms:group>
+                              <xforms:group ref=".[$page = 1]">
+                                <a class="btn btn-default disabled" title="First" href="#">
+                                  <span class="glyphicon glyphicon-fast-backward"></span>
+                                </a>
+                                <a class="btn btn-default disabled" title="Previous" href="#">
+                                  <span class="glyphicon glyphicon-backward"></span>
+                                </a>
+                              </xforms:group>
+                              <!-- current-->
+                              <button type="button" class="btn btn-default">
+				<b>
+				  <xforms:output value="$current"/>
+				</b>
+			      </button>
+                              <!-- next -->
+                              <xforms:group ref=".[$total &gt; $current]">
+                                <xforms:trigger>
+                                  <xforms:label><span class="glyphicon glyphicon-forward"></span></xforms:label>
+                                  <xforms:action ev:event="DOMActivate">
+                                    <xforms:setvalue ref="instance('control-instance')/page" value="$page + 1" />
+                                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', string($next))" />
+                                    <xforms:send submission="xquery-pagination" />
+                                  </xforms:action>
+                                </xforms:trigger>
+                                <xforms:trigger>
+                                  <xforms:label>
+                                    <span class="glyphicon glyphicon-fast-forward"></span>
+                                  </xforms:label>
+                                  <xforms:action ev:event="DOMActivate">
+                                    <xforms:setvalue ref="instance('control-instance')/page" value="$total" />
+                                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', string((($total - 1) * 20) + 1))" />
+                                    <xforms:send submission="xquery-pagination" />
+                                  </xforms:action>
+                                </xforms:trigger>
+                              </xforms:group>
+                              <xforms:group ref=".[not($total &gt; $current)]">
+                                <a class="btn btn-default disabled" title="Next" href="#">
+                                  <span class="glyphicon glyphicon-forward"></span>
+                                </a>
+                                <a class="btn btn-default disabled" href="#">
+                                  <span class="glyphicon glyphicon-fast-forward"></span>
+                                </a>
+                              </xforms:group>
+                            </div>
+                          </div>
+                        </xforms:group>
+                        <table class="table">
+                          <thead>
+                            <tr>
+                              <th style="width:5%">Type</th>
+                              <th>Title</th>
+                              <th style="width:10%">View</th>
+                              <th style="width:5%">Publish</th>
+                              <th style="width:5%">Delete</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <xforms:repeat nodeset="instance('pagination-result')//record">
+                              <xforms:var name="id" select="id" />
+                              <tr>
+                                <td class="text-center">
+                                  <xforms:output ref="type" />
+                                </td>
+                                <td>
+                                  <h4>
+                                    <xforms:group ref=".[type='nuds']">
+                                      <xforms:trigger appearance="minimal">
+                                        <xforms:label value="concat(title, ' (', $id, ')')" />
+                                        <xforms:action ev:event="DOMActivate">
+                                          <xforms:load show="replace" resource="edit/coin/?id={$id}" />
+                                        </xforms:action>
+                                      </xforms:trigger>
+                                    </xforms:group>
+                                    <xforms:group ref=".[type!='nuds']">
+                                      <xforms:output ref="title" />
+                                      <xforms:output ref="concat('(', $id, ')')" />
+                                    </xforms:group>
+                                  </h4>
+                                  <div>
+                                    <xforms:output ref="maintenanceStatus">
+                                      <xforms:label>Status</xforms:label>
+                                    </xforms:output>
+                                  </div>
+                                  <xforms:group ref="recordType">
+                                    <div>
+                                      <xforms:output ref=".">
+                                        <xforms:label>Record Type</xforms:label>
+                                      </xforms:output>
+                                    </div>
+                                  </xforms:group>
+                                  <xforms:group ref="obverse">
+                                    <div>
+                                      <xforms:output ref=".">
+                                        <xforms:label>Obverse</xforms:label>
+                                      </xforms:output>
+                                    </div>
+                                  </xforms:group>
+                                  <xforms:group ref="reverse">
+                                    <div>
+                                      <xforms:output ref=".">
+                                        <xforms:label>Reverse</xforms:label>
+                                      </xforms:output>
+                                    </div>
+                                  </xforms:group>
+                                </td>
+                                <td class="text-center">
+                                  <a href="{instance('config')/url}id/{$id}.xml" target="_blank">xml</a> | <a href="{instance('config')/url}id/{$id}" target="_blank">html</a>
+                                </td>
+                                <td class="text-center">
+                                  <!-- only enable publication if the maintenanceStatus allows it -->
+                                  <xforms:group ref=".[maintenanceStatus='new' or maintenanceStatus='revised' or maintenanceStatus='derived']">
+                                    <xforms:group ref="published[. = true()]">
+                                      <xforms:trigger appearance="minimal">
+                                        <xforms:label><span class="glyphicon glyphicon-{if (.=true()) then 'ok' else 'unchecked'}"></span></xforms:label>
+                                        <xforms:action ev:event="DOMActivate">
+                                          <xforms:var name="val" select="." as="xs:boolean" />
+                                          <xforms:setvalue ref="instance('control-instance')/id" value="$id" />
+                                          <!-- update publicationStatus -->
+                                          <xforms:setvalue ref="instance('control-instance')/publicationStatus">inProcess</xforms:setvalue>
+                                          <xforms:send submission="load-object" />
+                                          <!-- delete from Solr -->
+                                          <xforms:setvalue ref="instance('deleteId')/query" value="concat('recordId:&#x022;', instance('control-instance')/id, '&#x022;')" />
+                                          <xforms:send submission="delete-solr-doc" />
+                                          <xforms:setvalue ref="." value="false()" />
+                                        </xforms:action>
+                                      </xforms:trigger>
+                                    </xforms:group>
+                                    <xforms:group ref="published[. = false()]">
+                                      <xforms:trigger appearance="minimal">
+                                        <xforms:label><span class="glyphicon glyphicon-{if (.=true()) then 'ok' else 'unchecked'}"></span></xforms:label>
+                                        <xforms:action ev:event="DOMActivate">
+                                          <xforms:var name="val" select="." as="xs:boolean" />
+                                          <!-- publish the record if the box is checked -->
+                                          <xforms:setvalue ref="instance('control-instance')/id" value="$id" />
+                                          <xforms:setvalue ref="instance('control-instance')/publicationStatus">approved</xforms:setvalue>
+                                          <xforms:send submission="load-object" />
+                                          <!-- publish to solr -->
+                                          <xforms:send submission="nuds-to-solr" />
+                                          <xforms:send submission="submit-commit" />
+                                          <xforms:setvalue ref="." value="true()" />
+                                        </xforms:action>
+                                      </xforms:trigger>
+                                    </xforms:group>
+                                  </xforms:group>
+                                </td>
+                                <td class="text-center">
+                                  <xforms:trigger appearance="minimal">
+                                    <xforms:label>
+                                      <span class="glyphicon glyphicon-remove"></span>
+                                    </xforms:label>
+                                    <xforms:action ev:event="DOMActivate">
+                                      <xforms:setvalue ref="instance('control-instance')/id" value="$id" />
+                                      <xforms:dispatch target="delete" name="fr-show" />
+                                    </xforms:action>
+                                  </xforms:trigger>
+                                </td>
+                              </tr>
+                            </xforms:repeat>
+                          </tbody>
+                        </table>
+                      </xforms:group>
+                      <xforms:group ref=".[count(//record)=0]">
+                        <h3>No objects in collection.</h3>
+                      </xforms:group>
+                    </xforms:group>
+                  </xforms:case>
+                  <xforms:case id="union_type_catalog">
+                    <h2>Union Type Corpus</h2>
+                    <p>This collection is configured as a union type corpus of the following type series:</p>
+                    <p>The XML collection is not designed to store its own NUDS documents, but rather combines Solr and SPARQL queries from the designated series in the Numishare config, pointing search/browse responses to the external corpus.</p>
+                  </xforms:case>
+                </xforms:switch>
+              </div>
+            </xforms:case>
+          </xforms:switch>
+          <!--<fr:xforms-inspector/>-->
         </div>
+      </div>
     </div>
     <!-- *********************** DIALOGS ********************* -->
     <!-- ********* NUMISHARE-ADMIN ********* -->
     <fr:alert-dialog id="delete-collection-dialog">
-        <fr:label>Delete Collection</fr:label>
-        <fr:message>Are you sure you want to delete this collection? This is irreversible. It is recommended that you make a backup first.</fr:message>
-        <fr:negative-choice>
-            <fr:label>No</fr:label>
-        </fr:negative-choice>
-        <fr:positive-choice>
-            <fr:label>Yes</fr:label>
-            <xforms:action ev:event="DOMActivate">
-                <!-- set and submit the XQuery -->
-                <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='delete-collection'], '%COLLECTION%', instance('control-instance')/collection-name)" />
-                <xforms:send submission="xquery-db" />
-                <!-- delete the collection from the collections-list XML -->
-                <xforms:delete nodeset="instance('collections-list')/collection[@name=instance('control-instance')/collection-name]" />
-                <xforms:send submission="save-collections" />
-                <!-- update status and get collection metadata -->
-                <xforms:action ev:event="xforms-submit-done">
-                    <xforms:setvalue ref="instance('control-instance')/status">Collection successfully removed from eXist-db.</xforms:setvalue>
-                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='collection-metadata'], '%SEQUENCE%', string-join(instance('collections-list')/collection/@name, ','))" />
-                    <xforms:send submission="xquery-db" />
-                    <!-- blank collection name -->
-                    <xforms:setvalue ref="instance('control-instance')/collection-name" />
-                </xforms:action>
-            </xforms:action>
-        </fr:positive-choice>
+      <fr:label>Delete Collection</fr:label>
+      <fr:message>Are you sure you want to delete this collection? This is irreversible. It is recommended that you make a backup first.</fr:message>
+      <fr:negative-choice>
+        <fr:label>No</fr:label>
+      </fr:negative-choice>
+      <fr:positive-choice>
+        <fr:label>Yes</fr:label>
+        <xforms:action ev:event="DOMActivate">
+          <!-- set and submit the XQuery -->
+          <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='delete-collection'], '%COLLECTION%', instance('control-instance')/collection-name)" />
+          <xforms:send submission="xquery-db" />
+          <!-- delete the collection from the collections-list XML -->
+          <xforms:delete nodeset="instance('collections-list')/collection[@name=instance('control-instance')/collection-name]" />
+          <xforms:send submission="save-collections" />
+          <!-- update status and get collection metadata -->
+          <xforms:action ev:event="xforms-submit-done">
+            <xforms:setvalue ref="instance('control-instance')/status">Collection successfully removed from eXist-db.</xforms:setvalue>
+            <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='collection-metadata'], '%SEQUENCE%', string-join(instance('collections-list')/collection/@name, ','))" />
+            <xforms:send submission="xquery-db" />
+            <!-- blank collection name -->
+            <xforms:setvalue ref="instance('control-instance')/collection-name" />
+          </xforms:action>
+        </xforms:action>
+      </fr:positive-choice>
     </fr:alert-dialog>
     <!-- ********* NUMISHARE-EDITOR ********* -->
     <fr:alert-dialog id="delete">
-        <fr:label>Delete</fr:label>
-        <fr:message>Are you sure you want to delete this object?</fr:message>
-        <fr:negative-choice>
-            <fr:label>No</fr:label>
-        </fr:negative-choice>
-        <fr:positive-choice>
-            <fr:label>Yes</fr:label>
-            <xforms:action ev:event="DOMActivate">
-                <xforms:send submission="delete-object" />
-                <xforms:setvalue ref="instance('deleteId')/query" value="concat('recordId:&#x022;', instance('control-instance')/id, '&#x022;')" />
-                <xforms:send submission="delete-solr-doc" />
-                <!-- get new numCount -->
-                <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="instance('xqueries')/query[@id='collection-count']" />
-                <xforms:send submission="xquery-collection" />
-                <!-- reload table -->
-                <xforms:var name="page" select="number(instance('control-instance')/page)" />
-                <xforms:var name="start" select="(($page - 1) * 20) + 1" />
-                <xforms:var name="end" select="$page * 20" />
-                <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', string($start))" />
-                <xforms:send submission="xquery-pagination" />
-            </xforms:action>
-        </fr:positive-choice>
+      <fr:label>Delete</fr:label>
+      <fr:message>Are you sure you want to delete this object?</fr:message>
+      <fr:negative-choice>
+        <fr:label>No</fr:label>
+      </fr:negative-choice>
+      <fr:positive-choice>
+        <fr:label>Yes</fr:label>
+        <xforms:action ev:event="DOMActivate">
+          <xforms:send submission="delete-object" />
+          <xforms:setvalue ref="instance('deleteId')/query" value="concat('recordId:&#x022;', instance('control-instance')/id, '&#x022;')" />
+          <xforms:send submission="delete-solr-doc" />
+	  <!-- also delete from 3store TK -->
+
+          <!-- get new numCount -->
+          <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="instance('xqueries')/query[@id='collection-count']" />
+          <xforms:send submission="xquery-collection" />
+          <!-- reload table -->
+          <xforms:var name="page" select="number(instance('control-instance')/page)" />
+          <xforms:var name="start" select="(($page - 1) * 20) + 1" />
+          <xforms:var name="end" select="$page * 20" />
+          <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', string($start))" />
+          <xforms:send submission="xquery-pagination" />
+        </xforms:action>
+      </fr:positive-choice>
     </fr:alert-dialog>
     <!-- mass publication dialogs -->
     <fr:alert-dialog id="publish-all-dialog">
-        <fr:label>Publish All</fr:label>
-        <fr:message>Do you want to publish all objects? This may take several minutes.</fr:message>
-        <fr:negative-choice>
-            <fr:label>No</fr:label>
-        </fr:negative-choice>
-        <fr:positive-choice>
-            <fr:label>Yes</fr:label>
-            <xforms:action ev:event="DOMActivate">
-                <xforms:var name="count" select="if (instance('config')/collection_type='hoard') then '25' else '100'" />
-                <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='publish-all'], 'COUNT', $count)" />
-                <xforms:send submission="xquery-collection" />
-                <xforms:action ev:event="xforms-submit-done">
-                    <xforms:var name="tokens" select="tokenize(replace(instance('xquery-result')/report, ' ', ''), ',')" />
-                    <xforms:action xxforms:iterate="$tokens">
-                        <xforms:setvalue ref="instance('control-instance')/identifiers" value="context()" />
-                        <!-- get Solr document -->
-                        <xforms:send submission="generate-add-document" />
-                        <xforms:send submission="submit-commit" />
-                    </xforms:action>
-                    <!-- reload table -->
-                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')" />
-                    <xforms:send submission="xquery-pagination" />
-                </xforms:action>
+      <fr:label>Publish All</fr:label>
+      <fr:message>Do you want to publish all objects? This may take several minutes.</fr:message>
+      <fr:negative-choice>
+        <fr:label>No</fr:label>
+      </fr:negative-choice>
+      <fr:positive-choice>
+        <fr:label>Yes</fr:label>
+        <xforms:action ev:event="DOMActivate">
+	  <xforms:send submission="post-to-3store" />
+          <xforms:var name="count" select="if (instance('config')/collection_type='hoard') then '25' else '100'" />
+          <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='publish-all'], 'COUNT', $count)" />
+          <xforms:send submission="xquery-collection" />
+          <xforms:action ev:event="xforms-submit-done">
+            <xforms:var name="tokens" select="tokenize(replace(instance('xquery-result')/report, ' ', ''), ',')" />
+            <xforms:action xxforms:iterate="$tokens">
+              <xforms:setvalue ref="instance('control-instance')/identifiers" value="context()" />
+              <!-- get Solr document -->
+              <xforms:send submission="generate-add-document" />
+              <xforms:send submission="submit-commit" />
             </xforms:action>
-        </fr:positive-choice>
+	    
+            <!-- reload table -->
+            <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')" />
+            <xforms:send submission="xquery-pagination" />
+          </xforms:action>
+        </xforms:action>
+      </fr:positive-choice>
     </fr:alert-dialog>
+
     <fr:alert-dialog id="publish-3store-dialog">
-        <fr:label>Publish to Fueski</fr:label>
-        <fr:message>Do you want to publish to 3store? This may take several minutes.</fr:message>
-        <fr:negative-choice>
-            <fr:label>No</fr:label>
-        </fr:negative-choice>
-        <fr:positive-choice>
-            <fr:label>Yes</fr:label>
-            <xforms:action ev:event="DOMActivate">
-                <xforms:send submission="post-to-3store" />
-            </xforms:action>
-        </fr:positive-choice>
+      <fr:label>Publish to Fueski</fr:label>
+      <fr:message>Do you want to publish to 3store? This may take several minutes.</fr:message>
+      <fr:negative-choice>
+        <fr:label>No</fr:label>
+      </fr:negative-choice>
+      <fr:positive-choice>
+        <fr:label>Yes</fr:label>
+        <xforms:action ev:event="DOMActivate">
+          <xforms:send submission="post-to-3store" />
+        </xforms:action>
+      </fr:positive-choice>
+    </fr:alert-dialog>
+
+    <fr:alert-dialog id="unpublish-3store-dialog">
+      <fr:label>Publish to Fueski</fr:label>
+      <fr:message>Do you want to unpublish all collection triples in 3store? This may take several minutes.</fr:message>
+      <fr:negative-choice>
+        <fr:label>No</fr:label>
+      </fr:negative-choice>
+      <fr:positive-choice>
+        <fr:label>Yes</fr:label>
+        <xforms:action ev:event="DOMActivate">
+          <xforms:send submission="delete-all-from-3store" />
+        </xforms:action>
+      </fr:positive-choice>
     </fr:alert-dialog>
 
     <fr:alert-dialog id="unpublish-all">
-        <fr:label>Unpublish All</fr:label>
-        <fr:message>Do you want to unpublish all objects?</fr:message>
-        <fr:negative-choice>
-            <fr:label>No</fr:label>
-        </fr:negative-choice>
-        <fr:positive-choice>
-            <fr:label>Yes</fr:label>
-            <xforms:action ev:event="DOMActivate">
-                <xforms:setvalue ref="instance('deleteAll')/query" value="concat('collection-name:', instance('control-instance')/collection-name)" />
-                <xforms:send submission="delete-all" />
-                <!-- optimize index -->
-                <!--<xforms:send submission="optimize"></xforms:send>-->
-                <!-- reload table -->
-                <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')" />
-                <xforms:send submission="xquery-pagination" />
-            </xforms:action>
-        </fr:positive-choice>
+      <fr:label>Unpublish All</fr:label>
+      <fr:message>Do you want to unpublish all objects?</fr:message>
+      <fr:negative-choice>
+        <fr:label>No</fr:label>
+      </fr:negative-choice>
+      <fr:positive-choice>
+        <fr:label>Yes</fr:label>
+        <xforms:action ev:event="DOMActivate">
+          <xforms:setvalue ref="instance('deleteAll')/query" value="concat('collection-name:', instance('control-instance')/collection-name)" />
+          <xforms:send submission="delete-all" />
+          <!-- optimize index -->
+          <!--<xforms:send submission="optimize"></xforms:send>-->
+          <!-- reload table -->
+          <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')" />
+          <xforms:send submission="xquery-pagination" />
+        </xforms:action>
+      </fr:positive-choice>
     </fr:alert-dialog>
     <fr:alert-dialog id="republish-dialog">
-        <fr:label>Republish</fr:label>
-        <fr:message>Do you want to reindex currently published objects?</fr:message>
-        <fr:negative-choice>
-            <fr:label>No</fr:label>
-        </fr:negative-choice>
-        <fr:positive-choice>
-            <fr:label>Yes</fr:label>
-            <xforms:action ev:event="DOMActivate">
-                <xforms:send submission="republish" />
-                <xforms:send submission="optimize" ev:event="xforms-submit-done" />
-            </xforms:action>
-        </fr:positive-choice>
+      <fr:label>Republish</fr:label>
+      <fr:message>Do you want to reindex currently published objects?</fr:message>
+      <fr:negative-choice>
+        <fr:label>No</fr:label>
+      </fr:negative-choice>
+      <fr:positive-choice>
+        <fr:label>Yes</fr:label>
+        <xforms:action ev:event="DOMActivate">
+          <xforms:send submission="republish" />
+          <xforms:send submission="optimize" ev:event="xforms-submit-done" />
+        </xforms:action>
+      </fr:positive-choice>
     </fr:alert-dialog>
-</body>
+  </body>
 
 </html>

--- a/xforms/admin.xhtml
+++ b/xforms/admin.xhtml
@@ -1,83 +1,82 @@
 <?xml version="1.0" encoding="utf-8"?>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:xxforms="http://orbeon.org/oxf/xml/xforms"
-	xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:fr="http://orbeon.org/oxf/xml/form-runner" xmlns:exist="http://exist.sourceforge.net/NS/exist"
-	xmlns:xxi="http://orbeon.org/oxf/xml/xinclude" xmlns:numishare="https://github.comu/ewg118/numishare" xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:nuds="http://nomisma.org/nuds">
-	<head>
-		<title>Numishare: Administrative Interface</title>
-		<!-- Core + Skin CSS -->
-		<!--<link rel="stylesheet" href="/fr/style/bootstrap/css/bootstrap.css" type="text/css" />
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:xxforms="http://orbeon.org/oxf/xml/xforms"
+    xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:fr="http://orbeon.org/oxf/xml/form-runner" xmlns:exist="http://exist.sourceforge.net/NS/exist" xmlns:xxi="http://orbeon.org/oxf/xml/xinclude" xmlns:numishare="https://github.comu/ewg118/numishare" xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:nuds="http://nomisma.org/nuds">
+
+<head>
+    <title>Numishare: Administrative Interface</title>
+    <!-- Core + Skin CSS -->
+    <!--<link rel="stylesheet" href="/fr/style/bootstrap/css/bootstrap.css" type="text/css" />
 		<link rel="stylesheet" href="/fr/style/form-runner-bootstrap-override.css" type="text/css" />-->
-		<link rel="shortcut icon" href="/ops/images/orbeon-icon-16.ico" />
-		<link rel="icon" href="/ops/images/orbeon-icon-16.png" type="image/png" />
-		<link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
-		<script type="text/javascript" src="https://netdna.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-		<link rel="stylesheet" href="/apps/numishare/xforms/css/xforms.css" />
+    <link rel="shortcut icon" href="/ops/images/orbeon-icon-16.ico" />
+    <link rel="icon" href="/ops/images/orbeon-icon-16.png" type="image/png" />
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
+    <script type="text/javascript" src="https://netdna.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+    <link rel="stylesheet" href="/apps/numishare/xforms/css/xforms.css" />
 
-		<xforms:model xmlns="http://nomisma.org/nuds">
-			<!-- exist URL is stored in an XML file -->
-			<xforms:instance id="exist-config" xxforms:exclude-result-prefixes="#all">
-				<xi:include href="../exist-config.xml"/>
-			</xforms:instance>
+    <xforms:model xmlns="http://nomisma.org/nuds">
+        <!-- exist URL is stored in an XML file -->
+        <xforms:instance id="exist-config" xxforms:exclude-result-prefixes="#all">
+            <xi:include href="../exist-config.xml" />
+        </xforms:instance>
 
-			<xforms:instance id="control-instance" xxforms:exclude-result-prefixes="#all">
-				<controls xmlns="">
-					<id/>
-					<identifiers/>
-					<publicationStatus/>
-					<collection-name/>
-					<status/>
-					<error/>
-					<numFound/>
-					<page>1</page>
-					<query_input/>
-					<query_sent/>
-					<interface/>
-					<create-collection-trigger>false</create-collection-trigger>
-					<username/>
-				</controls>
-			</xforms:instance>
+        <xforms:instance id="control-instance" xxforms:exclude-result-prefixes="#all">
+            <controls xmlns="">
+                <id/>
+                <identifiers/>
+                <publicationStatus/>
+                <collection-name/>
+                <status/>
+                <error/>
+                <numFound/>
+                <page>1</page>
+                <query_input/>
+                <query_sent/>
+                <interface/>
+                <create-collection-trigger>false</create-collection-trigger>
+                <username/>
+            </controls>
+        </xforms:instance>
 
-			<xforms:instance id="config" xxforms:exclude-result-prefixes="#all">
-				<config xmlns=""/>
-			</xforms:instance>
+        <xforms:instance id="config" xxforms:exclude-result-prefixes="#all">
+            <config xmlns="" />
+        </xforms:instance>
 
-			<xforms:instance id="collections-list" xxforms:exclude-result-prefixes="#all">
-				<collections xmlns=""/>
-			</xforms:instance>
+        <xforms:instance id="collections-list" xxforms:exclude-result-prefixes="#all">
+            <collections xmlns="" />
+        </xforms:instance>
 
-			<xforms:instance id="config-template" xxforms:exclude-result-prefixes="#all">
-				<config xmlns="" version="19.04">
-					<title>Numishare</title>
-					<description>A short description of the collection.</description>
-					<logo/>
-					<url>http://localhost:8080/orbeon/numishare/</url>
-					<server-port>8080</server-port>
-					<sparql_endpoint>http://nomisma.org/query</sparql_endpoint>
-					<annotation_sparql_endpoint/>
-					<type_series/>
-					<specimens_per_page>48</specimens_per_page>
-					<solr_published>http://localhost:8080/solr/numishare-published/</solr_published>
-					<geonames_api_key/>
-					<mapboxKey/>
-					<contact/>
-					<google_analytics/>
-					<collection_type>object</collection_type>
-					<features_enabled>true</features_enabled>
-					<pelagios_enabled>false</pelagios_enabled>
-					<ctype_enabled>false</ctype_enabled>
-					<index_subtype_metadata>false</index_subtype_metadata>
-					<union_type_catalog enabled="false">
-						<series typeSeries="" uriSpace="" collectionName=""/>
-					</union_type_catalog>
-					<uri_space/>
-					<baselayers>
-						<layer enabled="true">mb_physical</layer>
-						<layer enabled="true">osm</layer>
-						<layer enabled="true">imperium</layer>
-					</baselayers>
-					<template>
+        <xforms:instance id="config-template" xxforms:exclude-result-prefixes="#all">
+            <config xmlns="" version="19.04">
+                <title>Numishare</title>
+                <description>A short description of the collection.</description>
+                <logo/>
+                <url>http://localhost:8080/orbeon/numishare/</url>
+                <server-port>8080</server-port>
+                <sparql_endpoint>http://nomisma.org/query</sparql_endpoint>
+                <annotation_sparql_endpoint/>
+                <type_series/>
+                <specimens_per_page>48</specimens_per_page>
+                <solr_published>http://localhost:8080/solr/numishare-published/</solr_published>
+                <geonames_api_key/>
+                <mapboxKey/>
+                <contact/>
+                <google_analytics/>
+                <collection_type>object</collection_type>
+                <features_enabled>true</features_enabled>
+                <pelagios_enabled>false</pelagios_enabled>
+                <ctype_enabled>false</ctype_enabled>
+                <index_subtype_metadata>false</index_subtype_metadata>
+                <union_type_catalog enabled="false">
+                    <series typeSeries="" uriSpace="" collectionName="" />
+                </union_type_catalog>
+                <uri_space/>
+                <baselayers>
+                    <layer enabled="true">mb_physical</layer>
+                    <layer enabled="true">osm</layer>
+                    <layer enabled="true">imperium</layer>
+                </baselayers>
+                <template>
 						<agencyName/>
 						<copyrightHolder/>
 						<collection/>
@@ -88,165 +87,163 @@
 						<owner/>
 						<repository/>
 					</template>
-					<includes/>
-					<installation_path>/usr/local/projects/numishare</installation_path>
-					<images>
-						<absolute_path>/usr/local/projects/numishare</absolute_path>
-						<iiif_server/>
-						<thumbnail>120</thumbnail>
-						<reference>400</reference>
-					</images>
-					<languages>
-						<language code="ar" enabled="false"/>
-						<language code="bg" enabled="false"/>
-						<language code="de" enabled="false"/>
-						<language code="el" enabled="false"/>
-						<language code="en" enabled="false"/>
-						<language code="es" enabled="false"/>
-						<language code="fr" enabled="false"/>
-						<language code="it" enabled="false"/>
-						<language code="nl" enabled="false"/>
-						<language code="pl" enabled="false"/>
-						<language code="ro" enabled="false"/>
-						<language code="ru" enabled="false"/>
-						<language code="sv" enabled="false"/>
-					</languages>
-					<positions/>
-					<localTypes/>
-					<facets>
-						<facet>artist_facet</facet>
-						<facet>authority_facet</facet>
-						<facet>citation_facet</facet>
-						<facet>coinType_facet</facet>
-						<facet>collection_facet</facet>
-						<facet>degree_facet</facet>
-						<facet>deity_facet</facet>
-						<facet>denomination_facet</facet>
-						<facet>department_facet</facet>
-						<facet>engraver_facet</facet>
-						<facet>era_facet</facet>
-						<facet>findspot_facet</facet>
-						<facet>issuer_facet</facet>
-						<facet>maker_facet</facet>
-						<facet>manufacture_facet</facet>
-						<facet>material_facet</facet>
-						<facet>mint_facet</facet>
-						<facet>objectType_facet</facet>
-						<facet>portrait_facet</facet>
-						<facet>reference_facet</facet>
-						<facet>region_facet</facet>
-						<facet>script_facet</facet>
-						<facet>state_facet</facet>
-						<facet>subject_facet</facet>
-					</facets>
-					<hoard_options>
-						<display_stub>authority,mint,date</display_stub>
-					</hoard_options>
-					<theme>
-						<orbeon_theme>default</orbeon_theme>
-						<themes_url>http://localhost:8080/orbeon/themes/</themes_url>
-						<layouts>
-							<results>
-								<image_location>right</image_location>
-							</results>
-							<display>
-								<nuds>
-									<orientation>vertical</orientation>
-									<image_location>left</image_location>
-								</nuds>
-							</display>
-						</layouts>
-					</theme>
-					<footer>
-						<div class="row">
-							<div class="col-md-12">
-								<p>Powered by <a href="https://github.com/ewg118/numishare" target="_blank">Numishare</a></p>
-							</div>
-						</div>
-					</footer>
-					<pages>
-						<index>
-							<p>
-								<a href="https://github.com/ewg118/numishare/">Numishare</a> is a free, open source, modularized system of Tomcat applications
-								for the web delivery of cultural heritage artifacts, with particular focus on coins and medals. Metadata are edited with XForms
-								and delivered with <a href="http://www.orbeon.com">Orbeon</a>, <a href="http://exist-db.org/exist/apps/homepage/index.html"
-									>eXist-db</a>, and <a href="http://lucene.apache.org/solr/">Apache Solr</a>.</p>
-						</index>
-						<compare enabled="true"/>
-						<analyze enabled="false"/>
-						<visualize enabled="true"/>
-						<apis enabled="true"/>
-						<feedback enabled="false">
-							<smtp-host>localhost</smtp-host>
-							<to type="">
-								<email></email>
-								<name></name>
-							</to>
-							<recipient-types>
-								<type>curatorial</type>
-								<type>technical</type>
-							</recipient-types>
-							<feedback-types>
-								<type type="curatorial">Cataloging error</type>
-								<type type="curatorial|technical">Comment or suggestion</type>
-								<type type="technical">Interface bug</type>					
-								<type type="curatorial">Other</type>
-							</feedback-types>
-						</feedback>
-						<symbols enabled="false"/>
-						<identify enabled="false"/>
-					</pages>
-					<navigation>
-						<tab href="results" id="browse"/>
-						<tab href="search" id="search"/>
-						<tab href="maps" id="maps"/>
-						<tab href="symbols" id="symbols"/>
-						<tab href="identify" id="identify" label="Identify a Coin"/>
-						<tab href="contributors" id="contributors"/>
-						<tab href="compare" id="compare"/>
-						<tab href="analyze" id="analyze"/>
-						<tab href="visualize" id="visualize"/>
-						<tab href="feedback" id="feedback"/>
-						<tab href="apis" id="apis" label="APIs"/>
-						<tab id="pages"/>
-						<tab id="languages-tab"/>
-					</navigation>
-				</config>
-			</xforms:instance>
-			<xforms:instance id="object" xxforms:exclude-result-prefixes="#all">
-				<nuds xmlns=""/>
-			</xforms:instance>
+                <includes/>
+                <installation_path>/usr/local/projects/numishare</installation_path>
+                <images>
+                    <absolute_path>/usr/local/projects/numishare</absolute_path>
+                    <iiif_server/>
+                    <thumbnail>120</thumbnail>
+                    <reference>400</reference>
+                </images>
+                <languages>
+                    <language code="ar" enabled="false" />
+                    <language code="bg" enabled="false" />
+                    <language code="de" enabled="false" />
+                    <language code="el" enabled="false" />
+                    <language code="en" enabled="false" />
+                    <language code="es" enabled="false" />
+                    <language code="fr" enabled="false" />
+                    <language code="it" enabled="false" />
+                    <language code="nl" enabled="false" />
+                    <language code="pl" enabled="false" />
+                    <language code="ro" enabled="false" />
+                    <language code="ru" enabled="false" />
+                    <language code="sv" enabled="false" />
+                </languages>
+                <positions/>
+                <localTypes/>
+                <facets>
+                    <facet>artist_facet</facet>
+                    <facet>authority_facet</facet>
+                    <facet>citation_facet</facet>
+                    <facet>coinType_facet</facet>
+                    <facet>collection_facet</facet>
+                    <facet>degree_facet</facet>
+                    <facet>deity_facet</facet>
+                    <facet>denomination_facet</facet>
+                    <facet>department_facet</facet>
+                    <facet>engraver_facet</facet>
+                    <facet>era_facet</facet>
+                    <facet>findspot_facet</facet>
+                    <facet>issuer_facet</facet>
+                    <facet>maker_facet</facet>
+                    <facet>manufacture_facet</facet>
+                    <facet>material_facet</facet>
+                    <facet>mint_facet</facet>
+                    <facet>objectType_facet</facet>
+                    <facet>portrait_facet</facet>
+                    <facet>reference_facet</facet>
+                    <facet>region_facet</facet>
+                    <facet>script_facet</facet>
+                    <facet>state_facet</facet>
+                    <facet>subject_facet</facet>
+                </facets>
+                <hoard_options>
+                    <display_stub>authority,mint,date</display_stub>
+                </hoard_options>
+                <theme>
+                    <orbeon_theme>default</orbeon_theme>
+                    <themes_url>http://localhost:8080/orbeon/themes/</themes_url>
+                    <layouts>
+                        <results>
+                            <image_location>right</image_location>
+                        </results>
+                        <display>
+                            <nuds>
+                                <orientation>vertical</orientation>
+                                <image_location>left</image_location>
+                            </nuds>
+                        </display>
+                    </layouts>
+                </theme>
+                <footer>
+                    <div class="row">
+                        <div class="col-md-12">
+                            <p>Powered by <a href="https://github.com/ewg118/numishare" target="_blank">Numishare</a></p>
+                        </div>
+                    </div>
+                </footer>
+                <pages>
+                    <index>
+                        <p>
+                            <a href="https://github.com/ewg118/numishare/">Numishare</a> is a free, open source, modularized system of Tomcat applications for the web delivery of cultural heritage artifacts, with particular focus on coins and medals.
+                            Metadata are edited with XForms and delivered with <a href="http://www.orbeon.com">Orbeon</a>, <a href="http://exist-db.org/exist/apps/homepage/index.html">eXist-db</a>, and <a href="http://lucene.apache.org/solr/">Apache Solr</a>.</p>
+                    </index>
+                    <compare enabled="true" />
+                    <analyze enabled="false" />
+                    <visualize enabled="true" />
+                    <apis enabled="true" />
+                    <feedback enabled="false">
+                        <smtp-host>localhost</smtp-host>
+                        <to type="">
+                            <email></email>
+                            <name></name>
+                        </to>
+                        <recipient-types>
+                            <type>curatorial</type>
+                            <type>technical</type>
+                        </recipient-types>
+                        <feedback-types>
+                            <type type="curatorial">Cataloging error</type>
+                            <type type="curatorial|technical">Comment or suggestion</type>
+                            <type type="technical">Interface bug</type>
+                            <type type="curatorial">Other</type>
+                        </feedback-types>
+                    </feedback>
+                    <symbols enabled="false" />
+                    <identify enabled="false" />
+                </pages>
+                <navigation>
+                    <tab href="results" id="browse" />
+                    <tab href="search" id="search" />
+                    <tab href="maps" id="maps" />
+                    <tab href="symbols" id="symbols" />
+                    <tab href="identify" id="identify" label="Identify a Coin" />
+                    <tab href="contributors" id="contributors" />
+                    <tab href="compare" id="compare" />
+                    <tab href="analyze" id="analyze" />
+                    <tab href="visualize" id="visualize" />
+                    <tab href="feedback" id="feedback" />
+                    <tab href="apis" id="apis" label="APIs" />
+                    <tab id="pages" />
+                    <tab id="languages-tab" />
+                </navigation>
+            </config>
+        </xforms:instance>
+        <xforms:instance id="object" xxforms:exclude-result-prefixes="#all">
+            <nuds xmlns="" />
+        </xforms:instance>
 
-			<xforms:instance id="languages">
-				<xi:include href="instances/languages.xml"/>
-			</xforms:instance>
+        <xforms:instance id="languages">
+            <xi:include href="instances/languages.xml" />
+        </xforms:instance>
 
-			<xforms:instance id="license-list">
-				<xi:include href="instances/licenses.xml"/>
-			</xforms:instance>
+        <xforms:instance id="license-list">
+            <xi:include href="instances/licenses.xml" />
+        </xforms:instance>
 
-			<xforms:instance id="rights-list">
-				<xi:include href="instances/rights.xml"/>
-			</xforms:instance>
+        <xforms:instance id="rights-list">
+            <xi:include href="instances/rights.xml" />
+        </xforms:instance>
 
-			<xforms:instance id="request" xxforms:exclude-result-prefixes="#all">
-				<request/>
-			</xforms:instance>
+        <xforms:instance id="request" xxforms:exclude-result-prefixes="#all">
+            <request/>
+        </xforms:instance>
 
-			<!-- XQuery instances -->
-			<xforms:instance id="eXist-xquery" xxforms:exclude-result-prefixes="#all">
-				<exist:query xmlns="">
-					<exist:text/>
-				</exist:query>
-			</xforms:instance>
+        <!-- XQuery instances -->
+        <xforms:instance id="eXist-xquery" xxforms:exclude-result-prefixes="#all">
+            <exist:query xmlns="">
+                <exist:text/>
+            </exist:query>
+        </xforms:instance>
 
-			<xforms:instance id="xqueries">
-				<queries xmlns="">
-					<query id="collection-count">
-						<![CDATA[xquery version "1.0"; <report>{count(collection())}</report>]]>
-					</query>
-					<query id="get-objects">
-						<![CDATA[xquery version "1.0";
+        <xforms:instance id="xqueries">
+            <queries xmlns="">
+                <query id="collection-count">
+                    <![CDATA[xquery version "1.0"; <report>{count(collection())}</report>]]>
+                </query>
+                <query id="get-objects">
+                    <![CDATA[xquery version "1.0";
 						declare namespace nuds="http://nomisma.org/nuds";
 						declare namespace nh="http://nomisma.org/nudsHoard";
 						<report> { 
@@ -276,9 +273,9 @@
 								else <record/>
 							}
 						</report>]]>
-					</query>
-					<query id="collection-metadata">
-						<![CDATA[xquery version "1.0";
+                </query>
+                <query id="collection-metadata">
+                    <![CDATA[xquery version "1.0";
 						let $sequence:= tokenize('%SEQUENCE%', ',')						
 						return
 						<metadata>
@@ -293,9 +290,9 @@
 								</collection>
 							}
 						</metadata>]]>
-					</query>
-					<query id="create-collection">
-						<![CDATA[xquery version "1.0";
+                </query>
+                <query id="create-collection">
+                    <![CDATA[xquery version "1.0";
 							declare namespace xmldb="http://exist-db.org/xquery/xmldb";
 							let $collection := '/db/%COLLECTION%'
 							let $path := '%PATH%'
@@ -305,17 +302,17 @@
 							for $doc in xmldb:get-child-resources($collection)							
 							return sm:chmod(xs:anyURI(concat($collection, '/', $doc)), 'rwxrwxrwx')
 						]]>
-					</query>
-					<query id="delete-collection">
-						<![CDATA[xquery version "1.0";
+                </query>
+                <query id="delete-collection">
+                    <![CDATA[xquery version "1.0";
 							declare namespace xmldb="http://exist-db.org/xquery/xmldb";
 							let $collection := '/db/%COLLECTION%'
 							return
 								xmldb:remove($collection)
 						]]>
-					</query>
-					<query id="query-objects">
-						<![CDATA[xquery version "1.0";
+                </query>
+                <query id="query-objects">
+                    <![CDATA[xquery version "1.0";
 						declare namespace nuds="http://nomisma.org/nuds";
 						declare namespace nh="http://nomisma.org/nudsHoard";
 						<report> { 
@@ -343,1157 +340,1113 @@
 							</record>
 							else <record/> 
 						} </report>]]>
-					</query>
-					<query id="publish-all">
-						<![CDATA[xquery version "1.0";
+                </query>
+                <query id="publish-all">
+                    <![CDATA[xquery version "1.0";
 						<report> { 
 							for $i at $position in collection()[descendant::*[local-name()='publicationStatus'] = 'approved' or descendant::*[local-name()='publicationStatus'] = 'approvedSubtype']
 								return concat(data($i//*:recordId), if ($position mod COUNT = 0) then ',' else '|') 
 							}
 						</report>]]>
-					</query>
-				</queries>
-			</xforms:instance>
+                </query>
+            </queries>
+        </xforms:instance>
 
-			<xforms:instance id="pagination-result">
-				<exist:result/>
-			</xforms:instance>
+        <xforms:instance id="pagination-result">
+            <exist:result/>
+        </xforms:instance>
 
-			<xforms:instance id="xquery-result">
-				<exist:result/>
-			</xforms:instance>
+        <xforms:instance id="xquery-result">
+            <exist:result/>
+        </xforms:instance>
 
-			<!-- solr response for id query -->
-			<xforms:instance id="published-response">
-				<response xmlns=""/>
-			</xforms:instance>
-			<xforms:instance id="list-published-response">
-				<response xmlns=""/>
-			</xforms:instance>
-			<xforms:instance id="is-published">
-				<response xmlns=""/>
-			</xforms:instance>
+        <!-- 3store query response -->
+        <xforms:instance id="3store-xquery-result">
+            <response xmlns="" />
+        </xforms:instance>
 
-			<!-- send to Solr -->
-			<xforms:instance id="addIndex" xxforms:exclude-result-prefixes="#all">
-				<add xmlns=""/>
-			</xforms:instance>
+        <!-- solr response for id query -->
+        <xforms:instance id="published-response">
+            <response xmlns="" />
+        </xforms:instance>
+        <xforms:instance id="list-published-response">
+            <response xmlns="" />
+        </xforms:instance>
+        <xforms:instance id="is-published">
+            <response xmlns="" />
+        </xforms:instance>
 
-			<!-- Instance for Solr commit-->
-			<xforms:instance id="sendCommit">
-				<commit/>
-			</xforms:instance>
+        <!-- send to Solr -->
+        <xforms:instance id="addIndex" xxforms:exclude-result-prefixes="#all">
+            <add xmlns="" />
+        </xforms:instance>
 
-			<!-- Solr optimize -->
-			<xforms:instance id="optimizeIndex">
-				<optimize/>
-			</xforms:instance>
+        <!-- Instance for Solr commit-->
+        <xforms:instance id="sendCommit">
+            <commit/>
+        </xforms:instance>
 
-			<!-- delete from Solr -->
-			<xforms:instance id="deleteId">
-				<delete xmlns="">
-					<query/>
-				</delete>
-			</xforms:instance>
-			<xforms:instance id="deleteAll">
-				<delete xmlns="">
-					<query/>
-				</delete>
-			</xforms:instance>
+        <!-- Solr optimize -->
+        <xforms:instance id="optimizeIndex">
+            <optimize/>
+        </xforms:instance>
 
-			<xforms:instance id="dump">
-				<dump xmlns=""/>
-			</xforms:instance>
+        <!-- delete from Solr -->
+        <xforms:instance id="deleteId">
+            <delete xmlns="">
+                <query/>
+            </delete>
+        </xforms:instance>
+        <xforms:instance id="deleteAll">
+            <delete xmlns="">
+                <query/>
+            </delete>
+        </xforms:instance>
 
-			<!-- ************************* BINDINGS ************************** -->
-			<xforms:bind nodeset="instance('control-instance')">
-				<xforms:bind id="create-collection-trigger" nodeset="create-collection-trigger" type="xs:boolean" readonly=". != true()"/>
-			</xforms:bind>
+        <xforms:instance id="dump">
+            <dump xmlns="" />
+        </xforms:instance>
 
-			<xforms:bind nodeset="instance('collections-list')"
-				constraint="count(//@name) = count(distinct-values(//@name)) and count(//@role) = count(distinct-values(//@role))">
-				<xforms:bind nodeset="collection">
-					<xforms:bind nodeset="@name" required="true()" type="xs:ID"/>
-					<xforms:bind nodeset="@role" required="true()" type="xs:ID"/>
-				</xforms:bind>
-			</xforms:bind>
+        <!-- ************************* BINDINGS ************************** -->
+        <xforms:bind nodeset="instance('control-instance')">
+            <xforms:bind id="create-collection-trigger" nodeset="create-collection-trigger" type="xs:boolean" readonly=". != true()" />
+        </xforms:bind>
 
-			<xforms:bind nodeset="instance('config-template')">
-				<xforms:bind nodeset="title" required="true()"/>
-				<xforms:bind nodeset="description" required="true()"/>
-				<xforms:bind nodeset="collection_type" required="true()"/>
-				<xforms:bind nodeset="installation_path" required="true()"/>
-				<xforms:bind nodeset="url" required="true()" constraint="matches(., 'https?://.+')"/>
-				<xforms:bind nodeset="solr_published" required="true()" constraint="matches(., 'https?://.+')"/>
-				<xforms:bind nodeset="template">
-					<!-- about the electronic record -->
-					<xforms:bind nodeset="agencyName" required="true()"/>
-					<xforms:bind nodeset="language" required="true()"/>
-					<xforms:bind nodeset="license" required="true()"/>
-					<xforms:bind nodeset="rights" required="true()"/>
-				</xforms:bind>
-			</xforms:bind>
+        <xforms:bind nodeset="instance('collections-list')" constraint="count(//@name) = count(distinct-values(//@name)) and count(//@role) = count(distinct-values(//@role))">
+            <xforms:bind nodeset="collection">
+                <xforms:bind nodeset="@name" required="true()" type="xs:ID" />
+                <xforms:bind nodeset="@role" required="true()" type="xs:ID" />
+            </xforms:bind>
+        </xforms:bind>
 
-			<xforms:bind nodeset="instance('config')">
-				<xforms:bind nodeset="union_type_catalog">
-					<xforms:bind nodeset="@enabled" type="xs:boolean"/>
-				</xforms:bind>
-			</xforms:bind>
+        <xforms:bind nodeset="instance('config-template')">
+            <xforms:bind nodeset="title" required="true()" />
+            <xforms:bind nodeset="description" required="true()" />
+            <xforms:bind nodeset="collection_type" required="true()" />
+            <xforms:bind nodeset="installation_path" required="true()" />
+            <xforms:bind nodeset="url" required="true()" constraint="matches(., 'https?://.+')" />
+            <xforms:bind nodeset="solr_published" required="true()" constraint="matches(., 'https?://.+')" />
+            <xforms:bind nodeset="template">
+                <!-- about the electronic record -->
+                <xforms:bind nodeset="agencyName" required="true()" />
+                <xforms:bind nodeset="language" required="true()" />
+                <xforms:bind nodeset="license" required="true()" />
+                <xforms:bind nodeset="rights" required="true()" />
+            </xforms:bind>
+        </xforms:bind>
 
-			<xforms:bind nodeset="instance('pagination-result')">
-				<xforms:bind nodeset="//record">
-					<xforms:bind nodeset="published" type="xs:boolean" readonly="../publicationStatus = 'approvedSubtype'"/>
-				</xforms:bind>
-			</xforms:bind>
+        <xforms:bind nodeset="instance('config')">
+            <xforms:bind nodeset="union_type_catalog">
+                <xforms:bind nodeset="@enabled" type="xs:boolean" />
+            </xforms:bind>
+        </xforms:bind>
 
-			<!-- **************** DYNAMIC VALIDATION CONTROLS ********************** -->
-			<xforms:action ev:event="xxforms-invalid" ev:observer="collections-list">
-				<xforms:setvalue ref="instance('control-instance')/create-collection-trigger" value="false()"/>
-			</xforms:action>
+        <xforms:bind nodeset="instance('pagination-result')">
+            <xforms:bind nodeset="//record">
+                <xforms:bind nodeset="published" type="xs:boolean" readonly="../publicationStatus = 'approvedSubtype'" />
+            </xforms:bind>
+        </xforms:bind>
 
-			<xforms:action ev:event="xxforms-valid" ev:observer="collections-list">
-				<xforms:setvalue ref="instance('control-instance')/create-collection-trigger" value="true()"
-					if="xxforms:valid(instance('config-template'), true())"/>
-			</xforms:action>
+        <!-- **************** DYNAMIC VALIDATION CONTROLS ********************** -->
+        <xforms:action ev:event="xxforms-invalid" ev:observer="collections-list">
+            <xforms:setvalue ref="instance('control-instance')/create-collection-trigger" value="false()" />
+        </xforms:action>
 
-			<xforms:action ev:event="xxforms-invalid" ev:observer="config-template">
-				<xforms:setvalue ref="instance('control-instance')/create-collection-trigger" value="false()"/>
-			</xforms:action>
+        <xforms:action ev:event="xxforms-valid" ev:observer="collections-list">
+            <xforms:setvalue ref="instance('control-instance')/create-collection-trigger" value="true()" if="xxforms:valid(instance('config-template'), true())" />
+        </xforms:action>
 
-			<xforms:action ev:event="xxforms-valid" ev:observer="config-template">
-				<xforms:setvalue ref="instance('control-instance')/create-collection-trigger" value="true()"
-					if="xxforms:valid(instance('collections-list'), true())"/>
-			</xforms:action>
+        <xforms:action ev:event="xxforms-invalid" ev:observer="config-template">
+            <xforms:setvalue ref="instance('control-instance')/create-collection-trigger" value="false()" />
+        </xforms:action>
 
-			<!-- ************************* SUBMISSIONS ************************** -->
-			<!-- load collections/roles config -->
-			<xforms:submission id="load-collections" serialization="none" method="get" resource="{instance('exist-config')/url}collections-list.xml"
-				replace="instance" instance="collections-list" xxforms:username="{instance('exist-config')/username}"
-				xxforms:password="{instance('exist-config')/password}">
-				<!-- if the config loads successfully, set the collection names based on authentication -->
-				<xforms:action ev:event="xforms-submit-done">
-					<!-- proceed with setting the interface for collection editing -->
-					<xforms:action if="not(instance('control-instance')/request-security/role = 'numishare-admin')">
-						<!-- if there is an eXist-db collection name that matches the associated Tomcat role -->
-						<xforms:action if="string(instance('collections-list')/collection[@role=instance('control-instance')/request-security/role]/@name)">
-							<xforms:setvalue ref="instance('control-instance')/collection-name"
-								value="instance('collections-list')/collection[@role=instance('control-instance')/request-security/role]/@name"/>
-							<!-- set interface -->
-							<xforms:setvalue ref="instance('control-instance')/interface">numishare-editor</xforms:setvalue>
-							<!-- load config -->
-							<xforms:send submission="load-config"/>
-						</xforms:action>
-						<!-- if there is not a collection matching the role, display the appropriate interface -->
-						<xforms:action if="not(string(instance('collections-list')/collection[@role=instance('control-instance')/request-security/role]/@name))">
-							<!-- set interface -->
-							<xforms:setvalue ref="instance('control-instance')/interface">unauthorized-user</xforms:setvalue>
-						</xforms:action>
-					</xforms:action>
-					<xforms:action if="instance('control-instance')/request-security/role = 'numishare-admin'">
-						<!-- get collection metadata -->
-						<xforms:setvalue ref="instance('eXist-xquery')/exist:text"
-							value="replace(instance('xqueries')/query[@id='collection-metadata'], '%SEQUENCE%', string-join(instance('collections-list')/collection/@name, ','))"/>
-						<xforms:send submission="xquery-db"/>
+        <xforms:action ev:event="xxforms-valid" ev:observer="config-template">
+            <xforms:setvalue ref="instance('control-instance')/create-collection-trigger" value="true()" if="xxforms:valid(instance('collections-list'), true())" />
+        </xforms:action>
 
-						<!-- set interface: if there is a session attribute for collection-name, then load the editor interface. otherwise load numishare-admin interface -->
-						<xforms:action if="string(xxforms:get-session-attribute('collection-name'))">
-							<xforms:setvalue ref="instance('control-instance')/collection-name" value="xxforms:get-session-attribute('collection-name')"/>
-							<xforms:setvalue ref="instance('control-instance')/interface">numishare-editor</xforms:setvalue>
-							<xforms:send submission="load-config"/>
-						</xforms:action>
-						<xforms:action if="not(string(xxforms:get-session-attribute('collection-name')))">
-							<xforms:setvalue ref="instance('control-instance')/interface">numishare-admin</xforms:setvalue>
-						</xforms:action>
+        <!-- ************************* SUBMISSIONS ************************** -->
+        <!-- load collections/roles config -->
+        <xforms:submission id="load-collections" serialization="none" method="get" resource="{instance('exist-config')/url}collections-list.xml" replace="instance" instance="collections-list" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
+            <!-- if the config loads successfully, set the collection names based on authentication -->
+            <xforms:action ev:event="xforms-submit-done">
+                <!-- proceed with setting the interface for collection editing -->
+                <xforms:action if="not(instance('control-instance')/request-security/role = 'numishare-admin')">
+                    <!-- if there is an eXist-db collection name that matches the associated Tomcat role -->
+                    <xforms:action if="string(instance('collections-list')/collection[@role=instance('control-instance')/request-security/role]/@name)">
+                        <xforms:setvalue ref="instance('control-instance')/collection-name" value="instance('collections-list')/collection[@role=instance('control-instance')/request-security/role]/@name" />
+                        <!-- set interface -->
+                        <xforms:setvalue ref="instance('control-instance')/interface">numishare-editor</xforms:setvalue>
+                        <!-- load config -->
+                        <xforms:send submission="load-config" />
+                    </xforms:action>
+                    <!-- if there is not a collection matching the role, display the appropriate interface -->
+                    <xforms:action if="not(string(instance('collections-list')/collection[@role=instance('control-instance')/request-security/role]/@name))">
+                        <!-- set interface -->
+                        <xforms:setvalue ref="instance('control-instance')/interface">unauthorized-user</xforms:setvalue>
+                    </xforms:action>
+                </xforms:action>
+                <xforms:action if="instance('control-instance')/request-security/role = 'numishare-admin'">
+                    <!-- get collection metadata -->
+                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='collection-metadata'], '%SEQUENCE%', string-join(instance('collections-list')/collection/@name, ','))" />
+                    <xforms:send submission="xquery-db" />
 
-					</xforms:action>
-				</xforms:action>
-				<!-- if there isn't a collection list XML, then this is the first time Numishare has been run. If the role is numishare-admin display the collection creation interface, otherwise block editing to unauthorized individuals -->
-				<xforms:action ev:event="xforms-submit-error">
-					<!-- set interface -->
-					<xforms:setvalue ref="instance('control-instance')/interface">numishare-admin</xforms:setvalue>
-				</xforms:action>
-			</xforms:submission>
+                    <!-- set interface: if there is a session attribute for collection-name, then load the editor interface. otherwise load numishare-admin interface -->
+                    <xforms:action if="string(xxforms:get-session-attribute('collection-name'))">
+                        <xforms:setvalue ref="instance('control-instance')/collection-name" value="xxforms:get-session-attribute('collection-name')" />
+                        <xforms:setvalue ref="instance('control-instance')/interface">numishare-editor</xforms:setvalue>
+                        <xforms:send submission="load-config" />
+                    </xforms:action>
+                    <xforms:action if="not(string(xxforms:get-session-attribute('collection-name')))">
+                        <xforms:setvalue ref="instance('control-instance')/interface">numishare-admin</xforms:setvalue>
+                    </xforms:action>
 
-			<xforms:submission id="save-collections" ref="instance('collections-list')" resource="{instance('exist-config')/url}/collections-list.xml"
-				method="put" replace="none" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
-				<xforms:message ev:event="xforms-submit-error" level="modal">Error Saving Collections List.</xforms:message>
-			</xforms:submission>
+                </xforms:action>
+            </xforms:action>
+            <!-- if there isn't a collection list XML, then this is the first time Numishare has been run. If the role is numishare-admin display the collection creation interface, otherwise block editing to unauthorized individuals -->
+            <xforms:action ev:event="xforms-submit-error">
+                <!-- set interface -->
+                <xforms:setvalue ref="instance('control-instance')/interface">numishare-admin</xforms:setvalue>
+            </xforms:action>
+        </xforms:submission>
 
-			<!-- loading, saving config -->
-			<xforms:submission id="load-config" serialization="none" method="get"
-				resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/config.xml" replace="instance" instance="config"
-				xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
-				<xforms:action ev:event="xforms-submit-done">
-					
-					<!-- evaluate the config to identify whether it is a union type corpus or not -->
-					<xforms:action if="instance('config')/union_type_catalog/@enabled = true()">
-						<xforms:toggle case="union_type_catalog"/>
-					</xforms:action>
-					<xforms:action if="not(instance('config')/union_type_catalog/@enabled = true())">
-						<!-- get the number of docs in the eXist collection() -->
-						<xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="instance('xqueries')/query[@id='collection-count']"/>
-						<xforms:send submission="xquery-collection"/>
-						<xforms:setvalue ref="instance('control-instance')/numFound" value="number(instance('xquery-result'))"/>
-						<!-- set value in control instance -->
-						
-						<xforms:var name="end" select="if(instance('control-instance')/numFound &gt; 20) then 20 else instance('control-instance')/numFound"/>
-						<!-- get list of files for page 1, replacing START and END -->
-						<xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')"/>
-						<xforms:send submission="xquery-pagination"/>
-						
-						<xforms:toggle case="collection-interface"/>
-					</xforms:action>
-				</xforms:action>
-				<!-- if config.xml doesn't exist, then create the exist collection with necessary files -->
-				<xforms:message ev:event="xforms-submit-error" level="model">Error: there is no config for this collection.</xforms:message>
-			</xforms:submission>
+        <xforms:submission id="save-collections" ref="instance('collections-list')" resource="{instance('exist-config')/url}/collections-list.xml" method="put" replace="none" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
+            <xforms:message ev:event="xforms-submit-error" level="modal">Error Saving Collections List.</xforms:message>
+        </xforms:submission>
 
-			<xforms:submission id="save-config" ref="instance('config-template')"
-				resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/config.xml" method="put" replace="none"
-				xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
-				<xforms:message ev:event="xforms-submit-error" level="modal">Error Saving Config.</xforms:message>
-				<xforms:action ev:event="xforms-submit-done">
-					<!-- create eXist-db collections, config file, and XQuery files -->
-					<xforms:setvalue ref="instance('eXist-xquery')/exist:text"
-						value="replace(replace(instance('xqueries')/query[@id='create-collection'], '%COLLECTION%', instance('control-instance')/collection-name), '%PATH%', instance('config-template')/installation_path)"/>
-					<xforms:send submission="xquery-db"/>
+        <!-- loading, saving config -->
+        <xforms:submission id="load-config" serialization="none" method="get" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/config.xml" replace="instance" instance="config" xxforms:username="{instance('exist-config')/username}"
+            xxforms:password="{instance('exist-config')/password}">
+            <xforms:action ev:event="xforms-submit-done">
 
-					<!-- submit collection metadata once again before switching the interface -->
-					<xforms:action ev:event="xforms-submit-done">
-						<xforms:setvalue ref="instance('eXist-xquery')/exist:text"
-							value="replace(instance('xqueries')/query[@id='collection-metadata'], '%SEQUENCE%', string-join(instance('collections-list')/collection/@name, ','))"/>
-						<xforms:send submission="xquery-db"/>
-					</xforms:action>
-				</xforms:action>
-			</xforms:submission>
+                <!-- evaluate the config to identify whether it is a union type corpus or not -->
+                <xforms:action if="instance('config')/union_type_catalog/@enabled = true()">
+                    <xforms:toggle case="union_type_catalog" />
+                </xforms:action>
+                <xforms:action if="not(instance('config')/union_type_catalog/@enabled = true())">
+                    <!-- get the number of docs in the eXist collection() -->
+                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="instance('xqueries')/query[@id='collection-count']" />
+                    <xforms:send submission="xquery-collection" />
+                    <xforms:setvalue ref="instance('control-instance')/numFound" value="number(instance('xquery-result'))" />
+                    <!-- set value in control instance -->
 
-			<!--***************** XQUERY ******************-->
-			<!-- xquery for getting and processing query results into pages of items -->
-			<xforms:submission id="xquery-pagination" ref="instance('eXist-xquery')"
-				resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects" method="post" replace="instance"
-				instance="pagination-result" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
-				<xforms:setvalue ref="instance('control-instance')/error" ev:event="xforms-submit-error">Error querying eXist database.</xforms:setvalue>
-				<xforms:action ev:event="xforms-submit-done">
-					<!--iterate through docs, check for publication -->
-					<xforms:action xxforms:iterate="instance('pagination-result')//record">
-						<xforms:setvalue ref="instance('control-instance')/id" value="context()/id"/>
-						<xforms:send submission="query-solr-for-publication"/>
-					</xforms:action>
-				</xforms:action>
-			</xforms:submission>
+                    <xforms:var name="end" select="if(instance('control-instance')/numFound &gt; 20) then 20 else instance('control-instance')/numFound" />
+                    <!-- get list of files for page 1, replacing START and END -->
+                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')" />
+                    <xforms:send submission="xquery-pagination" />
 
-			<xforms:submission id="xquery-collection" ref="instance('eXist-xquery')"
-				resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects" method="post" replace="instance"
-				instance="xquery-result" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
-				<xforms:setvalue ref="instance('control-instance')/error" ev:event="xforms-submit-error">Error querying eXist database.</xforms:setvalue>
-			</xforms:submission>
+                    <xforms:toggle case="collection-interface" />
+                </xforms:action>
+            </xforms:action>
+            <!-- if config.xml doesn't exist, then create the exist collection with necessary files -->
+            <xforms:message ev:event="xforms-submit-error" level="model">Error: there is no config for this collection.</xforms:message>
+        </xforms:submission>
 
-			<xforms:submission id="xquery-db" ref="instance('eXist-xquery')" resource="{instance('exist-config')/url}" method="post" replace="instance"
-				instance="xquery-result" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
-				<xforms:setvalue ref="instance('control-instance')/error" ev:event="xforms-submit-error">Error querying eXist database.</xforms:setvalue>
-			</xforms:submission>
-			<!-- ************************* CRUD ON OBJECT RECORDS ********************** -->
-			<!-- update publication status -->
-			<xforms:submission id="load-object" serialization="none" method="get"
-				resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects/{instance('control-instance')/id}.xml"
-				xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}" replace="instance"
-				instance="object">
-				<xforms:message ev:event="xforms-submit-error" level="modal">Error loading file.</xforms:message>
-				<xforms:action ev:event="xforms-submit-done">
-					<xforms:setvalue ref="instance('object')/nuds:control/nuds:publicationStatus" value="instance('control-instance')/publicationStatus"/>
-					<xforms:send submission="save-object"/>
-				</xforms:action>
-			</xforms:submission>
+        <xforms:submission id="save-config" ref="instance('config-template')" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/config.xml" method="put" replace="none" xxforms:username="{instance('exist-config')/username}"
+            xxforms:password="{instance('exist-config')/password}">
+            <xforms:message ev:event="xforms-submit-error" level="modal">Error Saving Config.</xforms:message>
+            <xforms:action ev:event="xforms-submit-done">
+                <!-- create eXist-db collections, config file, and XQuery files -->
+                <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(replace(instance('xqueries')/query[@id='create-collection'], '%COLLECTION%', instance('control-instance')/collection-name), '%PATH%', instance('config-template')/installation_path)"
+                />
+                <xforms:send submission="xquery-db" />
 
-			<xforms:submission id="save-object" ref="instance('object')" xxforms:username="{instance('exist-config')/username}"
-				xxforms:password="{instance('exist-config')/password}"
-				resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects/{instance('control-instance')/id}.xml"
-				method="put" replace="none">
-				<xforms:message ev:event="xforms-submit-error" level="modal">Error saving file.</xforms:message>
-			</xforms:submission>
+                <!-- submit collection metadata once again before switching the interface -->
+                <xforms:action ev:event="xforms-submit-done">
+                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='collection-metadata'], '%SEQUENCE%', string-join(instance('collections-list')/collection/@name, ','))" />
+                    <xforms:send submission="xquery-db" />
+                </xforms:action>
+            </xforms:action>
+        </xforms:submission>
 
-			<xforms:submission id="delete-object"
-				resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects/{instance('control-instance')/id}.xml"
-				method="delete" replace="none" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
-				<xforms:setvalue ev:event="xforms-submit-done" ref="instance('control-instance')/status">Object successfully deleted.</xforms:setvalue>
-			</xforms:submission>
+        <!--***************** XQUERY ******************-->
+        <!-- xquery for getting and processing query results into pages of items -->
+        <xforms:submission id="xquery-pagination" ref="instance('eXist-xquery')" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects" method="post" replace="instance" instance="pagination-result" xxforms:username="{instance('exist-config')/username}"
+            xxforms:password="{instance('exist-config')/password}">
+            <xforms:setvalue ref="instance('control-instance')/error" ev:event="xforms-submit-error">Error querying eXist database.</xforms:setvalue>
+            <xforms:action ev:event="xforms-submit-done">
+                <!--iterate through docs, check for publication -->
+                <xforms:action xxforms:iterate="instance('pagination-result')//record">
+                    <xforms:setvalue ref="instance('control-instance')/id" value="context()/id" />
+                    <xforms:send submission="query-solr-for-publication" />
+                </xforms:action>
+            </xforms:action>
+        </xforms:submission>
 
-			<!-- ************************* SOLR SUBMISSIONS ************************** -->
-			<!-- query Solr for the id of all currently published documents and repost them to solr -->
-			<xforms:submission id="republish" serialization="none" method="get"
-				resource="{instance('config')/solr_published}select/?q=collection-name:{instance('control-instance')/collection-name}&amp;rows=100000&amp;start=0&amp;fl=id"
-				replace="instance" instance="list-published-response">
-				<xforms:message ev:event="xforms-submit-error" level="modal">Solr is inaccessible. Please check Solr configuration. [ADM001]</xforms:message>
-				<xforms:action ev:event="xforms-submit-done">
-					<xforms:setvalue ref="instance('control-instance')/identifiers"
-						value="string-join(instance('list-published-response')//doc/str[@name='id'], '|')"/>
+        <xforms:submission id="xquery-collection" ref="instance('eXist-xquery')" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects" method="post" replace="instance" instance="xquery-result" xxforms:username="{instance('exist-config')/username}"
+            xxforms:password="{instance('exist-config')/password}">
+            <xforms:setvalue ref="instance('control-instance')/error" ev:event="xforms-submit-error">Error querying eXist database.</xforms:setvalue>
+        </xforms:submission>
 
-					<!-- get Solr document -->
-					<xforms:send submission="generate-add-document"/>
-					<!-- optimize index -->
-					<xforms:send submission="optimize"/>
-					<!-- reload table -->
-					<xforms:delete nodeset="instance('list')/*"/>
-					<xforms:send submission="query-solr"/>
-				</xforms:action>
-			</xforms:submission>
-			<!-- access service to read in pre-transformed solr doc -->
-			<xforms:submission id="nuds-to-solr" method="get" replace="instance" instance="addIndex" serialization="none"
-				resource="/numishare/{instance('control-instance')/collection-name}/id/{instance('control-instance')/id}.solr">
-				<xforms:message ev:event="xforms-submit-error" level="modal">Error transforming XML record to Solr document.</xforms:message>
-				<xforms:send ev:event="xforms-submit-done" submission="post-solr-doc"/>
-			</xforms:submission>
+        <xforms:submission id="xquery-db" ref="instance('eXist-xquery')" resource="{instance('exist-config')/url}" method="post" replace="instance" instance="xquery-result" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
+            <xforms:setvalue ref="instance('control-instance')/error" ev:event="xforms-submit-error">Error querying eXist database.</xforms:setvalue>
+        </xforms:submission>
+        <!-- ************************* CRUD ON OBJECT RECORDS ********************** -->
+        <!-- update publication status -->
+        <xforms:submission id="load-object" serialization="none" method="get" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects/{instance('control-instance')/id}.xml" xxforms:username="{instance('exist-config')/username}"
+            xxforms:password="{instance('exist-config')/password}" replace="instance" instance="object">
+            <xforms:message ev:event="xforms-submit-error" level="modal">Error loading file.</xforms:message>
+            <xforms:action ev:event="xforms-submit-done">
+                <xforms:setvalue ref="instance('object')/nuds:control/nuds:publicationStatus" value="instance('control-instance')/publicationStatus" />
+                <xforms:send submission="save-object" />
+            </xforms:action>
+        </xforms:submission>
 
-			<!-- post instance to Solr -->
-			<xforms:submission id="post-solr-doc" resource="{instance('config')/solr_published}update" ref="instance('addIndex')" instance="addIndex"
-				replace="instance" method="post">
-				<xforms:message ev:event="xforms-submit-error" level="modal">Data Failed to POST to Solr. Index may be offline or URL is
-					incorrect.</xforms:message>
-				<xforms:setvalue ev:event="xforms-submit-done" ref="instance('control-instance')/status">Successfully published to Solr.</xforms:setvalue>
-			</xforms:submission>
+        <xforms:submission id="save-object" ref="instance('object')" xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects/{instance('control-instance')/id}.xml"
+            method="put" replace="none">
+            <xforms:message ev:event="xforms-submit-error" level="modal">Error saving file.</xforms:message>
+        </xforms:submission>
 
-			<!-- delete from Solr -->
-			<xforms:submission id="delete-solr-doc" resource="{instance('config')/solr_published}update" ref="instance('deleteId')" instance="deleteId"
-				replace="none" method="post">
-				<xforms:action ev:event="xforms-submit-done">
-					<xforms:setvalue ref="instance('control-instance')/status">Successfully deleted document from Solr.</xforms:setvalue>
-					<xforms:send submission="submit-commit"/>
-				</xforms:action>
-				<xforms:message ev:event="xforms-submit-error" level="modal">Data Failed to POST to Solr.</xforms:message>
-			</xforms:submission>
+        <xforms:submission id="delete-object" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/objects/{instance('control-instance')/id}.xml" method="delete" replace="none" xxforms:username="{instance('exist-config')/username}"
+            xxforms:password="{instance('exist-config')/password}">
+            <xforms:setvalue ev:event="xforms-submit-done" ref="instance('control-instance')/status">Object successfully deleted.</xforms:setvalue>
+        </xforms:submission>
 
-			<xforms:submission id="delete-all" resource="{instance('config')/solr_published}update" ref="instance('deleteAll')" instance="deleteAll"
-				replace="none" method="post">
-				<xforms:message ev:event="xforms-submit-error" level="modal">Error issuing delete query</xforms:message>
-				<xforms:action ev:event="xforms-submit-done">
-					<xforms:send submission="submit-commit"/>
-					<xforms:setvalue ref="instance('control-instance')/status">Objects removed from search index.</xforms:setvalue>
-				</xforms:action>
-			</xforms:submission>
+        <!-- ************************* SOLR SUBMISSIONS ************************** -->
+        <!-- query Solr for the id of all currently published documents and repost them to solr -->
+        <xforms:submission id="republish" serialization="none" method="get" resource="{instance('config')/solr_published}select/?q=collection-name:{instance('control-instance')/collection-name}&amp;rows=100000&amp;start=0&amp;fl=id" replace="instance" instance="list-published-response">
+            <xforms:message ev:event="xforms-submit-error" level="modal">Solr is inaccessible. Please check Solr configuration. [ADM001]</xforms:message>
+            <xforms:action ev:event="xforms-submit-done">
+                <xforms:setvalue ref="instance('control-instance')/identifiers" value="string-join(instance('list-published-response')//doc/str[@name='id'], '|')" />
 
-			<!-- pass identifiers URL parameter to xquery process in Cocoon to generate large Solr add document -->
-			<xforms:submission id="generate-add-document" method="get" replace="instance" instance="addIndex" serialization="none"
-				resource="/numishare/{instance('control-instance')/collection-name}/ingest?identifiers={instance('control-instance')/identifiers}">
-				<xforms:message ev:event="xforms-submit-error" level="modal">Error getting Solr document from XQuery ingestion pipeline.</xforms:message>
-				<xforms:action ev:event="xforms-submit-done">
-					<xforms:send submission="post-solr-doc"/>
-				</xforms:action>
-			</xforms:submission>
+                <!-- get Solr document -->
+                <xforms:send submission="generate-add-document" />
+                <!-- optimize index -->
+                <xforms:send submission="optimize" />
+                <!-- reload table -->
+                <xforms:delete nodeset="instance('list')/*" />
+                <xforms:send submission="query-solr" />
+            </xforms:action>
+        </xforms:submission>
+        <!-- access service to read in pre-transformed solr doc -->
+        <xforms:submission id="nuds-to-solr" method="get" replace="instance" instance="addIndex" serialization="none" resource="/numishare/{instance('control-instance')/collection-name}/id/{instance('control-instance')/id}.solr">
+            <xforms:message ev:event="xforms-submit-error" level="modal">Error transforming XML record to Solr document.</xforms:message>
+            <xforms:send ev:event="xforms-submit-done" submission="post-solr-doc" />
+        </xforms:submission>
 
-			<!-- send commit -->
-			<xforms:submission id="submit-commit" resource="{instance('config')/solr_published}update" ref="instance('sendCommit')" instance="sendCommit"
-				replace="none" method="post">
-				<xforms:message ev:event="xforms-submit-error" level="modal">Failed to commit to Solr index.</xforms:message>
-			</xforms:submission>
+        <!-- post instance to Solr -->
+        <xforms:submission id="post-solr-doc" resource="{instance('config')/solr_published}update" ref="instance('addIndex')" instance="addIndex" replace="instance" method="post">
+            <xforms:message ev:event="xforms-submit-error" level="modal">Data Failed to POST to Solr. Index may be offline or URL is incorrect.
+            </xforms:message>
+            <xforms:setvalue ev:event="xforms-submit-done" ref="instance('control-instance')/status">Successfully published to Solr.</xforms:setvalue>
+        </xforms:submission>
 
-			<!-- send optimize -->
-			<xforms:submission id="optimize" resource="{instance('config')/solr_published}update" ref="instance('optimizeIndex')" instance="optimizeIndex"
-				replace="none" method="post">
-				<xforms:message ev:event="xforms-submit-error" level="modal">Failed to optimize Solr index.</xforms:message>
-			</xforms:submission>
+        <!-- delete from Solr -->
+        <xforms:submission id="delete-solr-doc" resource="{instance('config')/solr_published}update" ref="instance('deleteId')" instance="deleteId" replace="none" method="post">
+            <xforms:action ev:event="xforms-submit-done">
+                <xforms:setvalue ref="instance('control-instance')/status">Successfully deleted document from Solr.</xforms:setvalue>
+                <xforms:send submission="submit-commit" />
+            </xforms:action>
+            <xforms:message ev:event="xforms-submit-error" level="modal">Data Failed to POST to Solr.</xforms:message>
+        </xforms:submission>
 
-			<!-- submission to query solr to see if the document is published -->
-			<xforms:submission id="query-solr-for-publication" serialization="none" method="get"
-				resource="{instance('config')/solr_published}select/?q=collection-name:{instance('control-instance')/collection-name} AND id:&#x022;{instance('control-instance')/id}&#x022;"
-				replace="instance" instance="published-response">
-				<!-- if the document is found in solr, get the updated solr doc -->
-				<xforms:setvalue ev:event="xforms-submit-done" if="instance('published-response')/result[@name='response']/@numFound = '1'"
-					ref="instance('pagination-result')//record[id=instance('control-instance')/id]/published" value="true()"/>
-			</xforms:submission>
+        <xforms:submission id="delete-all" resource="{instance('config')/solr_published}update" ref="instance('deleteAll')" instance="deleteAll" replace="none" method="post">
+            <xforms:message ev:event="xforms-submit-error" level="modal">Error issuing delete query</xforms:message>
+            <xforms:action ev:event="xforms-submit-done">
+                <xforms:send submission="submit-commit" />
+                <xforms:setvalue ref="instance('control-instance')/status">Objects removed from search index.</xforms:setvalue>
+            </xforms:action>
+        </xforms:submission>
 
-			<!-- ************************* EXIST SUBMISSIONS FOR POSTING TO TRIPLE STORE************************** -->
-			<xforms:submission id="post-to-3store" ref="instance('collections-list')"
-					   resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/post-to-3store.xq"
-					   method="get" replace="none"
-					   xxforms:username="{instance('exist-config')/username}" xxforms:password="{instance('exist-config')/password}">
-				<xforms:message ev:event="xforms-submit-error" level="modal">Error posting to 3store.</xforms:message>
-			</xforms:submission>
+        <!-- pass identifiers URL parameter to xquery process in Cocoon to generate large Solr add document -->
+        <xforms:submission id="generate-add-document" method="get" replace="instance" instance="addIndex" serialization="none" resource="/numishare/{instance('control-instance')/collection-name}/ingest?identifiers={instance('control-instance')/identifiers}">
+            <xforms:message ev:event="xforms-submit-error" level="modal">Error getting Solr document from XQuery ingestion pipeline.</xforms:message>
+            <xforms:action ev:event="xforms-submit-done">
+                <xforms:send submission="post-solr-doc" />
+            </xforms:action>
+        </xforms:submission>
 
-			<!-- ************************* XFORMS-MODEL-CONSTRUCT-DONE ************************** -->
-			<xforms:action ev:event="xforms-model-construct-done">
-				<!-- load numishare config file on xforms construction -->
-				<xforms:insert context="instance('control-instance')" nodeset="collection-name" position="after"
-					origin="xxforms:call-xpl('oxf:/apps/numishare/xpl/get-authentication.xpl', 'dump', instance('dump'), 'data')"/>
+        <!-- send commit -->
+        <xforms:submission id="submit-commit" resource="{instance('config')/solr_published}update" ref="instance('sendCommit')" instance="sendCommit" replace="none" method="post">
+            <xforms:message ev:event="xforms-submit-error" level="modal">Failed to commit to Solr index.</xforms:message>
+        </xforms:submission>
 
-				<!-- if authentication has not been enabled, trigger a case -->
-				<xforms:action if="not(string(instance('control-instance')/request-security/role))">
-					<!-- set interface -->
-					<xforms:setvalue ref="instance('control-instance')/interface">unauthorized-user</xforms:setvalue>
-				</xforms:action>
-				<xforms:action if="string(instance('control-instance')/request-security/role)">
-					<xforms:send submission="load-collections"/>
-				</xforms:action>
-			</xforms:action>
+        <!-- send optimize -->
+        <xforms:submission id="optimize" resource="{instance('config')/solr_published}update" ref="instance('optimizeIndex')" instance="optimizeIndex" replace="none" method="post">
+            <xforms:message ev:event="xforms-submit-error" level="modal">Failed to optimize Solr index.</xforms:message>
+        </xforms:submission>
 
-			<!-- ************************* XFORMS-READY ************************** -->
-			<!-- set case on xforms-ready -->
-			<xforms:action ev:event="xforms-ready">
-				<xforms:toggle case="{instance('control-instance')/interface}"/>
-			</xforms:action>
-		</xforms:model>
-	</head>
-	<body>
-		<xforms:var name="display_path">./</xforms:var>
-		<xforms:group ref=".[not(instance('control-instance')/interface = 'unauthorized-user')]">
-			<xi:include href="header.xml"/>
-		</xforms:group>
-		<div class="container-fluid">
-			<div class="row">
-				<div class="col-md-12">
-					<xforms:switch>
-						<xforms:case id="unauthorized-user">
-							<h2>Unauthorized User</h2>
-							<p>You are seeing this interface either because authentication has not been enabled for the Numishare administrative panel or there
-								is no matching eXist-db collection for your role. If it is the latter case, please log in as the numishare-admin role and create
-								a new collection for the associated Tomcat role.</p>
-						</xforms:case>
-						<xforms:case id="numishare-admin">
-							<div id="form">
-								<xforms:group
-									ref=".[count(distinct-values(instance('collections-list')/collection/@name)) != count(instance('collections-list')/collection/@name)]">
-									<div class="alert alert-box alert-danger">
-										<span class="glyphicon glyphicon-exclamation-sign"></span>
-										<strong>Alert:</strong> Collection of this name already exists.</div>
-								</xforms:group>
-								<xforms:group
-									ref=".[count(distinct-values(instance('collections-list')/collection/@role)) != count(instance('collections-list')/collection/@role)]">
-									<div class="alert alert-box alert-warning">
-										<span class="glyphicon glyphicon-exclamation-sign"></span>
-										<strong>Alert:</strong>A role cannot be bound to more than one collection.</div>
-								</xforms:group>
-								<xforms:group ref=".[instance('control-instance')/status/text()]">
-									<div class="alert alert-box alert-success">
-										<p><span class="glyphicon glyphicon-info-sign"></span>
-											<strong>Status:</strong>
-											<xforms:output ref="instance('control-instance')/status"/>
-										</p>
-									</div>
-								</xforms:group>
-								<h2>Numishare Administration</h2>
-								<xforms:switch>
-									<xforms:case id="collections-list-interface">
-										<div>
-											<xforms:group ref=".[count(instance('collections-list')/collection) &gt; 0]">
-												<xforms:group ref="instance('collections-list')">
-													<h3>Collections List<small><xforms:trigger appearance="minimal"><xforms:label><span
+        <!-- submission to query solr to see if the document is published -->
+        <xforms:submission id="query-solr-for-publication" serialization="none" method="get" resource="{instance('config')/solr_published}select/?q=collection-name:{instance('control-instance')/collection-name} AND id:&#x022;{instance('control-instance')/id}&#x022;"
+            replace="instance" instance="published-response">
+            <!-- if the document is found in solr, get the updated solr doc -->
+            <xforms:setvalue ev:event="xforms-submit-done" if="instance('published-response')/result[@name='response']/@numFound = '1'" ref="instance('pagination-result')//record[id=instance('control-instance')/id]/published" value="true()" />
+        </xforms:submission>
+
+        <!-- ************************* EXIST SUBMISSIONS FOR POSTING TO TRIPLE STORE************************** -->
+        <xforms:submission id="post-to-3store" resource="{instance('exist-config')/url}{instance('control-instance')/collection-name}/post-to-3store.xq" serialization="none" method="get" replace="instance" instance="3store-xquery-result" xxforms:username="{instance('exist-config')/username}"
+            xxforms:password="{instance('exist-config')/password}">
+
+            <xforms:action ev:event="xforms-submit-error">
+                <xforms:setvalue ref="instance('control-instance')/status" value="event('response-body')" />
+                <xforms:message level="modal">
+                    Error posting to 3store.
+                </xforms:message>
+            </xforms:action>
+            <xforms:action ev:event="xforms-submit-done">
+                <xforms:action if="number(instance('xquery-result'))">
+                    <xforms:setvalue ref="instance('control-instance')/status">Successfully posted to 3store.</xforms:setvalue>
+                </xforms:action>
+            </xforms:action>
+        </xforms:submission>
+
+        <!-- ************************* XFORMS-MODEL-CONSTRUCT-DONE ************************** -->
+        <xforms:action ev:event="xforms-model-construct-done">
+            <!-- load numishare config file on xforms construction -->
+            <xforms:insert context="instance('control-instance')" nodeset="collection-name" position="after" origin="xxforms:call-xpl('oxf:/apps/numishare/xpl/get-authentication.xpl', 'dump', instance('dump'), 'data')" />
+
+            <!-- if authentication has not been enabled, trigger a case -->
+            <xforms:action if="not(string(instance('control-instance')/request-security/role))">
+                <!-- set interface -->
+                <xforms:setvalue ref="instance('control-instance')/interface">unauthorized-user</xforms:setvalue>
+            </xforms:action>
+            <xforms:action if="string(instance('control-instance')/request-security/role)">
+                <xforms:send submission="load-collections" />
+            </xforms:action>
+        </xforms:action>
+
+        <!-- ************************* XFORMS-READY ************************** -->
+        <!-- set case on xforms-ready -->
+        <xforms:action ev:event="xforms-ready">
+            <xforms:toggle case="{instance('control-instance')/interface}" />
+        </xforms:action>
+    </xforms:model>
+</head>
+
+<body>
+    <xforms:var name="display_path">./</xforms:var>
+    <xforms:group ref=".[not(instance('control-instance')/interface = 'unauthorized-user')]">
+        <xi:include href="header.xml" />
+    </xforms:group>
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-md-12">
+                <xforms:switch>
+                    <xforms:case id="unauthorized-user">
+                        <h2>Unauthorized User</h2>
+                        <p>You are seeing this interface either because authentication has not been enabled for the Numishare administrative panel or there is no matching eXist-db collection for your role. If it is the latter case, please log in as the numishare-admin
+                            role and create a new collection for the associated Tomcat role.</p>
+                    </xforms:case>
+                    <xforms:case id="numishare-admin">
+                        <div id="form">
+                            <xforms:group ref=".[count(distinct-values(instance('collections-list')/collection/@name)) != count(instance('collections-list')/collection/@name)]">
+                                <div class="alert alert-box alert-danger">
+                                    <span class="glyphicon glyphicon-exclamation-sign"></span>
+                                    <strong>Alert:</strong> Collection of this name already exists.</div>
+                            </xforms:group>
+                            <xforms:group ref=".[count(distinct-values(instance('collections-list')/collection/@role)) != count(instance('collections-list')/collection/@role)]">
+                                <div class="alert alert-box alert-warning">
+                                    <span class="glyphicon glyphicon-exclamation-sign"></span>
+                                    <strong>Alert:</strong>A role cannot be bound to more than one collection.</div>
+                            </xforms:group>
+                            <xforms:group ref=".[instance('control-instance')/status/text()]">
+                                <div class="alert alert-box alert-success">
+                                    <p><span class="glyphicon glyphicon-info-sign"></span>
+                                        <strong>Status:</strong>
+                                        <xforms:output ref="instance('control-instance')/status" />
+                                    </p>
+                                </div>
+                            </xforms:group>
+                            <h2>Numishare Administration</h2>
+                            <xforms:switch>
+                                <xforms:case id="collections-list-interface">
+                                    <div>
+                                        <xforms:group ref=".[count(instance('collections-list')/collection) &gt; 0]">
+                                            <xforms:group ref="instance('collections-list')">
+                                                <h3>Collections List<small><xforms:trigger appearance="minimal"><xforms:label><span
 																		class="glyphicon glyphicon-plus"></span>Add collection</xforms:label><xforms:action
 																	ev:event="DOMActivate">
 																	<xforms:insert context="instance('collections-list')" nodeset="./child::node()[last()]"
 																		origin="xforms:element('collection', (xforms:attribute('name', ''), xforms:attribute('role', '')))"/>
 																	<xforms:toggle case="add-collection-interface"/>
 																</xforms:action></xforms:trigger></small></h3>
-													<table class="table">
-														<thead>
-															<tr>
-																<th>Collection</th>
-																<th>Role</th>
-																<th>Title</th>
-																<th style="width:50%">Description</th>
-																<th>Actions</th>
-															</tr>
-														</thead>
-														<tbody>
-															<xforms:repeat nodeset="collection">
-																<xforms:var name="name" select="@name"/>
-																<tr>
-																	<td>
-																		<xforms:output ref="$name"/>
-																	</td>
-																	<td>
-																		<xforms:output ref="@role"/>
-																	</td>
-																	<td>
-																		<xforms:trigger appearance="minimal">
-																			<xforms:label value="instance('xquery-result')//collection[@id=$name]/title"/>
-																			<xforms:load ev:event="DOMActivate"
-																				ref=" instance('xquery-result')//collection[@id=$name]/url" show="new"/>
-																		</xforms:trigger>
-																	</td>
-																	<td>
-																		<xforms:output ref="instance('xquery-result')//collection[@id=$name]/description"/>
-																	</td>
-																	<td>
-																		<xforms:trigger appearance="minimal">
-																			<xforms:label><span class="glyphicon glyphicon-pencil"></span></xforms:label>
-																			<xforms:hint>Edit Collection</xforms:hint>
-																			<xforms:action ev:event="DOMActivate">
-																				<!-- set session attribute of the selected collection name -->
-																				<xforms:setvalue ref="instance('control-instance')/collection-name"
-																				value="$name"/>
-																				<xforms:insert context="."
-																				origin="xxforms:set-session-attribute('collection-name', instance('control-instance')/collection-name)"/>
-																				<!-- load the associated config and display the Numishare editor interface -->
-																				<xforms:send submission="load-config"/>
-																				<xforms:toggle case="numishare-editor"/>
-																			</xforms:action>
-																		</xforms:trigger>
-																		<xforms:trigger appearance="minimal">
-																			<xforms:label><span class="glyphicon glyphicon-trash"></span></xforms:label>
-																			<xforms:hint>Delete Collection</xforms:hint>
-																			<xforms:action ev:event="DOMActivate">
-																				<xforms:setvalue ref="instance('control-instance')/collection-name"
-																				value="$name"/>
-																				<xforms:dispatch target="delete-collection-dialog" name="fr-show"/>
-																			</xforms:action>
-																		</xforms:trigger>
-																	</td>
-																</tr>
-															</xforms:repeat>
-														</tbody>
-													</table>
-												</xforms:group>
-											</xforms:group>
-											<xforms:group ref=".[count(instance('collections-list')/collection) = 0]">
-												<p>There are no collections in Numishare. <xforms:trigger appearance="minimal"><xforms:label><span
-																class="glyphicon glyphicon-plus"></span>Add one.</xforms:label><xforms:action
-															ev:event="DOMActivate">
-															<xforms:insert context="instance('collections-list')" nodeset="./child::node()[last()]"
-																origin="xforms:element('collection', (xforms:attribute('name', ''), xforms:attribute('role', '')))"/>
-															<xforms:toggle case="add-collection-interface"/>
-														</xforms:action></xforms:trigger></p>
-											</xforms:group>
-										</div>
-									</xforms:case>
-									<xforms:case id="add-collection-interface">
-										<div>
-											<h3>Add New Collection</h3>
-											<div>
-												<xforms:group ref="instance('collections-list')/collection[last()]">
-													<div>
-														<xforms:input ref="@role">
-															<xforms:label>Tomcat Role</xforms:label>
-															<xforms:alert>Must conform to xs:ID</xforms:alert>
-														</xforms:input>
-													</div>
-													<div>
-														<xforms:input ref="@name">
-															<xforms:label>Collection Name</xforms:label>
-															<xforms:alert>Must conform to xs:ID</xforms:alert>
-															<xforms:action ev:event="xforms-value-changed">
-																<xforms:var name="name" select="."/>
-																<xforms:setvalue ref="instance('config-template')/url"
-																	value="concat('http://localhost:8080/orbeon/numishare/', $name, '/')"/>
-																<xforms:setvalue ref="instance('config-template')/uri_space"
-																	value="concat('http://localhost:8080/orbeon/numishare/', $name, '/id/')"/>
-															</xforms:action>
-														</xforms:input>
-													</div>
-												</xforms:group>
-												<xforms:group ref="instance('config-template')">
-													<div>
-														<xforms:input ref="installation_path">
-															<xforms:label>Installation Directory</xforms:label>
-															<xforms:alert>Required</xforms:alert>
-														</xforms:input>
-														<p class="text-muted">The absolute path to the directory to which Numishare was installed. This is
-															necessary for writing XQuery files from the disk into the eXist-db collection.</p>
-													</div>
-													<h4>Boilerplate</h4>
-													<div>
-														<xforms:input ref="title">
-															<xforms:label>Collection Title</xforms:label>
-															<xforms:alert>Required</xforms:alert>
-														</xforms:input>
-													</div>
-													<div>
-														<xforms:input ref="description">
-															<xforms:label>Description</xforms:label>
-															<xforms:alert>Required</xforms:alert>
-														</xforms:input>
-													</div>
-													<div>
-														<xforms:select1 ref="collection_type">
-															<xforms:label>Collection Type</xforms:label>
-															<xforms:item>
-																<xforms:label>Object</xforms:label>
-																<xforms:value>object</xforms:value>
-															</xforms:item>
-															<xforms:item>
-																<xforms:label>Coin Type</xforms:label>
-																<xforms:value>cointype</xforms:value>
-															</xforms:item>
-															<xforms:item>
-																<xforms:label>Hoard</xforms:label>
-																<xforms:value>hoard</xforms:value>
-															</xforms:item>
-															<xforms:alert>Required</xforms:alert>
-														</xforms:select1>
-													</div>
-													<div>
-														<xforms:input ref="template/agencyName">
-															<xforms:label>Maintainer</xforms:label>
-															<xforms:alert>Required</xforms:alert>
-															<xforms:hint>The agent responsible for maintaining the data.</xforms:hint>
-														</xforms:input>
-													</div>
-													<div>
-														<xforms:select1 ref="template/language">
-															<xforms:label>Default Language</xforms:label>
-															<xforms:item>
-																<xforms:label>Select Language...</xforms:label>
-																<xforms:value/>
-															</xforms:item>
-															<xforms:itemset nodeset="instance('languages')//language">
-																<xforms:label ref="."/>
-																<xforms:value ref="@value"/>
-															</xforms:itemset>
-															<xforms:alert>Required</xforms:alert>
-														</xforms:select1>
-													</div>
-													<div>
-														<xforms:select1 ref="template/rights">
-															<xforms:label>Rights Statement</xforms:label>
-															<xforms:alert>Required</xforms:alert>
-															<xforms:item>
-																<xforms:label>Select License...</xforms:label>
-																<xforms:value/>
-															</xforms:item>
-															<xforms:itemset nodeset="instance('rights-list')/statement">
-																<xforms:label ref="."/>
-																<xforms:value ref="@value"/>
-															</xforms:itemset>
-														</xforms:select1>
-													</div>
-													<div>
-														<xforms:select1 ref="template/license[@for='images']">
-															<xforms:label>Image License</xforms:label>
-															<xforms:alert>Required</xforms:alert>
-															<xforms:item>
-																<xforms:label>Select License...</xforms:label>
-																<xforms:value/>
-															</xforms:item>
-															<xforms:itemset nodeset="instance('license-list')/images/statement">
-																<xforms:label ref="."/>
-																<xforms:value ref="@value"/>
-															</xforms:itemset>
-														</xforms:select1>
-													</div>
-													<div>
-														<xforms:select1 ref="template/license[@for='data']">
-															<xforms:label>Data License</xforms:label>
-															<xforms:alert>Required</xforms:alert>
-															<xforms:item>
-																<xforms:label>Select License...</xforms:label>
-																<xforms:value/>
-															</xforms:item>
-															<xforms:itemset nodeset="instance('license-list')/data/statement">
-																<xforms:label ref="."/>
-																<xforms:value ref="@value"/>
-															</xforms:itemset>
-														</xforms:select1>
-													</div>
-													<h4>URLS</h4>
-													<div>
-														<xforms:input ref="url">
-															<xforms:label>Public Site</xforms:label>
-															<xforms:alert>Required, must be a URL</xforms:alert>
-															<xforms:action ev:event="xforms-value-changed">
-																<xforms:var name="uri" select="."/>
-																<xforms:setvalue ref="instance('config-template')/uri_space" value="concat($uri, 'id/')"/>
-															</xforms:action>
-														</xforms:input>
-													</div>
-													<div>
-														<xforms:input ref="solr_published">
-															<xforms:label>Solr Published</xforms:label>
-															<xforms:alert>Required, must be a URL</xforms:alert>
-															<xforms:hint>Unlikely to need changing.</xforms:hint>
-														</xforms:input>
-													</div>
-												</xforms:group>
-												<xforms:trigger>
-													<xforms:label>Cancel</xforms:label>
-													<xforms:action ev:event="DOMActivate">
-														<xforms:delete nodeset="instance('collections-list')/collection[last()]"/>
-														<xforms:toggle case="collections-list-interface"/>
-													</xforms:action>
-												</xforms:trigger>
-												<xforms:trigger bind="create-collection-trigger">
-													<xforms:label>Create</xforms:label>
-													<xforms:action ev:event="DOMActivate">
-														<!-- save collections list, config, and XQL files -->
-														<xforms:send submission="save-collections"/>
-														<xforms:action ev:event="xforms-submit-done">
-															<xforms:setvalue ref="instance('control-instance')/status">Collection successfully created in
-																eXist-db.</xforms:setvalue>
-															<xforms:setvalue ref="instance('control-instance')/collection-name"
-																value="instance('collections-list')/collection[last()]/@name"/>
-															<xforms:send submission="save-config"/>
-														</xforms:action>
-														<xforms:toggle case="collections-list-interface"/>
-													</xforms:action>
-												</xforms:trigger>
-											</div>
-										</div>
-									</xforms:case>
-								</xforms:switch>
-							</div>
-						</xforms:case>
-						<xforms:case id="numishare-editor">
-							<div id="form">
-								
-								<xforms:group ref=".[xxforms:is-user-in-role('numishare-admin')]">
-									<div>
-										<xforms:trigger appearance="minimal">
-											<xforms:label><span class="glyphicon glyphicon-arrow-left"></span> Return to Collections List</xforms:label>
-											<xforms:action ev:event="DOMActivate">
-												<!-- clear session attributes -->
-												<xforms:setvalue ref="instance('control-instance')/collection-name"/>
-												<xforms:insert context="." origin="xxforms:set-session-attribute('collection-name', '')"/>
-												<!-- get collection metadata -->
-												<xforms:setvalue ref="instance('eXist-xquery')/exist:text"
-													value="replace(instance('xqueries')/query[@id='collection-metadata'], '%SEQUENCE%', string-join(instance('collections-list')/collection/@name, ','))"/>
-												<xforms:send submission="xquery-db"/>
-												<xforms:action ev:event="xforms-submit-done">
-													<xforms:toggle case="numishare-admin"/>
-												</xforms:action>
-											</xforms:action>
-										</xforms:trigger>
-									</div>
-								</xforms:group>
-								<xforms:group ref=".[instance('control-instance')/status/text()]">
-									<div class="alert alert-box alert-success">
-										<p><span class="glyphicon glyphicon-info-sign"></span>
-											<strong>Status:</strong>
-											<xforms:output ref="instance('control-instance')/status"/>
-										</p>
-									</div>
-								</xforms:group>
-								
-								<xforms:switch>
-									<xforms:case id="collection-interface">										
-										<h2>Object Management</h2>
-										<ul>
-											<li>
-												<a href="edit/coin/">Create New Coin or Medal</a>
-											</li>
-											<!--<li>
+                                                <table class="table">
+                                                    <thead>
+                                                        <tr>
+                                                            <th>Collection</th>
+                                                            <th>Role</th>
+                                                            <th>Title</th>
+                                                            <th style="width:50%">Description</th>
+                                                            <th>Actions</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                        <xforms:repeat nodeset="collection">
+                                                            <xforms:var name="name" select="@name" />
+                                                            <tr>
+                                                                <td>
+                                                                    <xforms:output ref="$name" />
+                                                                </td>
+                                                                <td>
+                                                                    <xforms:output ref="@role" />
+                                                                </td>
+                                                                <td>
+                                                                    <xforms:trigger appearance="minimal">
+                                                                        <xforms:label value="instance('xquery-result')//collection[@id=$name]/title" />
+                                                                        <xforms:load ev:event="DOMActivate" ref=" instance('xquery-result')//collection[@id=$name]/url" show="new" />
+                                                                    </xforms:trigger>
+                                                                </td>
+                                                                <td>
+                                                                    <xforms:output ref="instance('xquery-result')//collection[@id=$name]/description" />
+                                                                </td>
+                                                                <td>
+                                                                    <xforms:trigger appearance="minimal">
+                                                                        <xforms:label><span class="glyphicon glyphicon-pencil"></span></xforms:label>
+                                                                        <xforms:hint>Edit Collection</xforms:hint>
+                                                                        <xforms:action ev:event="DOMActivate">
+                                                                            <!-- set session attribute of the selected collection name -->
+                                                                            <xforms:setvalue ref="instance('control-instance')/collection-name" value="$name" />
+                                                                            <xforms:insert context="." origin="xxforms:set-session-attribute('collection-name', instance('control-instance')/collection-name)" />
+                                                                            <!-- load the associated config and display the Numishare editor interface -->
+                                                                            <xforms:send submission="load-config" />
+                                                                            <xforms:toggle case="numishare-editor" />
+                                                                        </xforms:action>
+                                                                    </xforms:trigger>
+                                                                    <xforms:trigger appearance="minimal">
+                                                                        <xforms:label><span class="glyphicon glyphicon-trash"></span></xforms:label>
+                                                                        <xforms:hint>Delete Collection</xforms:hint>
+                                                                        <xforms:action ev:event="DOMActivate">
+                                                                            <xforms:setvalue ref="instance('control-instance')/collection-name" value="$name" />
+                                                                            <xforms:dispatch target="delete-collection-dialog" name="fr-show" />
+                                                                        </xforms:action>
+                                                                    </xforms:trigger>
+                                                                </td>
+                                                            </tr>
+                                                        </xforms:repeat>
+                                                    </tbody>
+                                                </table>
+                                            </xforms:group>
+                                        </xforms:group>
+                                        <xforms:group ref=".[count(instance('collections-list')/collection) = 0]">
+                                            <p>There are no collections in Numishare.
+                                                <xforms:trigger appearance="minimal">
+                                                    <xforms:label><span class="glyphicon glyphicon-plus"></span>Add one.</xforms:label>
+                                                    <xforms:action ev:event="DOMActivate">
+                                                        <xforms:insert context="instance('collections-list')" nodeset="./child::node()[last()]" origin="xforms:element('collection', (xforms:attribute('name', ''), xforms:attribute('role', '')))" />
+                                                        <xforms:toggle case="add-collection-interface" />
+                                                    </xforms:action>
+                                                </xforms:trigger>
+                                            </p>
+                                        </xforms:group>
+                                    </div>
+                                </xforms:case>
+                                <xforms:case id="add-collection-interface">
+                                    <div>
+                                        <h3>Add New Collection</h3>
+                                        <div>
+                                            <xforms:group ref="instance('collections-list')/collection[last()]">
+                                                <div>
+                                                    <xforms:input ref="@role">
+                                                        <xforms:label>Tomcat Role</xforms:label>
+                                                        <xforms:alert>Must conform to xs:ID</xforms:alert>
+                                                    </xforms:input>
+                                                </div>
+                                                <div>
+                                                    <xforms:input ref="@name">
+                                                        <xforms:label>Collection Name</xforms:label>
+                                                        <xforms:alert>Must conform to xs:ID</xforms:alert>
+                                                        <xforms:action ev:event="xforms-value-changed">
+                                                            <xforms:var name="name" select="." />
+                                                            <xforms:setvalue ref="instance('config-template')/url" value="concat('http://localhost:8080/orbeon/numishare/', $name, '/')" />
+                                                            <xforms:setvalue ref="instance('config-template')/uri_space" value="concat('http://localhost:8080/orbeon/numishare/', $name, '/id/')" />
+                                                        </xforms:action>
+                                                    </xforms:input>
+                                                </div>
+                                            </xforms:group>
+                                            <xforms:group ref="instance('config-template')">
+                                                <div>
+                                                    <xforms:input ref="installation_path">
+                                                        <xforms:label>Installation Directory</xforms:label>
+                                                        <xforms:alert>Required</xforms:alert>
+                                                    </xforms:input>
+                                                    <p class="text-muted">The absolute path to the directory to which Numishare was installed. This is necessary for writing XQuery files from the disk into the eXist-db collection.</p>
+                                                </div>
+                                                <h4>Boilerplate</h4>
+                                                <div>
+                                                    <xforms:input ref="title">
+                                                        <xforms:label>Collection Title</xforms:label>
+                                                        <xforms:alert>Required</xforms:alert>
+                                                    </xforms:input>
+                                                </div>
+                                                <div>
+                                                    <xforms:input ref="description">
+                                                        <xforms:label>Description</xforms:label>
+                                                        <xforms:alert>Required</xforms:alert>
+                                                    </xforms:input>
+                                                </div>
+                                                <div>
+                                                    <xforms:select1 ref="collection_type">
+                                                        <xforms:label>Collection Type</xforms:label>
+                                                        <xforms:item>
+                                                            <xforms:label>Object</xforms:label>
+                                                            <xforms:value>object</xforms:value>
+                                                        </xforms:item>
+                                                        <xforms:item>
+                                                            <xforms:label>Coin Type</xforms:label>
+                                                            <xforms:value>cointype</xforms:value>
+                                                        </xforms:item>
+                                                        <xforms:item>
+                                                            <xforms:label>Hoard</xforms:label>
+                                                            <xforms:value>hoard</xforms:value>
+                                                        </xforms:item>
+                                                        <xforms:alert>Required</xforms:alert>
+                                                    </xforms:select1>
+                                                </div>
+                                                <div>
+                                                    <xforms:input ref="template/agencyName">
+                                                        <xforms:label>Maintainer</xforms:label>
+                                                        <xforms:alert>Required</xforms:alert>
+                                                        <xforms:hint>The agent responsible for maintaining the data.</xforms:hint>
+                                                    </xforms:input>
+                                                </div>
+                                                <div>
+                                                    <xforms:select1 ref="template/language">
+                                                        <xforms:label>Default Language</xforms:label>
+                                                        <xforms:item>
+                                                            <xforms:label>Select Language...</xforms:label>
+                                                            <xforms:value/>
+                                                        </xforms:item>
+                                                        <xforms:itemset nodeset="instance('languages')//language">
+                                                            <xforms:label ref="." />
+                                                            <xforms:value ref="@value" />
+                                                        </xforms:itemset>
+                                                        <xforms:alert>Required</xforms:alert>
+                                                    </xforms:select1>
+                                                </div>
+                                                <div>
+                                                    <xforms:select1 ref="template/rights">
+                                                        <xforms:label>Rights Statement</xforms:label>
+                                                        <xforms:alert>Required</xforms:alert>
+                                                        <xforms:item>
+                                                            <xforms:label>Select License...</xforms:label>
+                                                            <xforms:value/>
+                                                        </xforms:item>
+                                                        <xforms:itemset nodeset="instance('rights-list')/statement">
+                                                            <xforms:label ref="." />
+                                                            <xforms:value ref="@value" />
+                                                        </xforms:itemset>
+                                                    </xforms:select1>
+                                                </div>
+                                                <div>
+                                                    <xforms:select1 ref="template/license[@for='images']">
+                                                        <xforms:label>Image License</xforms:label>
+                                                        <xforms:alert>Required</xforms:alert>
+                                                        <xforms:item>
+                                                            <xforms:label>Select License...</xforms:label>
+                                                            <xforms:value/>
+                                                        </xforms:item>
+                                                        <xforms:itemset nodeset="instance('license-list')/images/statement">
+                                                            <xforms:label ref="." />
+                                                            <xforms:value ref="@value" />
+                                                        </xforms:itemset>
+                                                    </xforms:select1>
+                                                </div>
+                                                <div>
+                                                    <xforms:select1 ref="template/license[@for='data']">
+                                                        <xforms:label>Data License</xforms:label>
+                                                        <xforms:alert>Required</xforms:alert>
+                                                        <xforms:item>
+                                                            <xforms:label>Select License...</xforms:label>
+                                                            <xforms:value/>
+                                                        </xforms:item>
+                                                        <xforms:itemset nodeset="instance('license-list')/data/statement">
+                                                            <xforms:label ref="." />
+                                                            <xforms:value ref="@value" />
+                                                        </xforms:itemset>
+                                                    </xforms:select1>
+                                                </div>
+                                                <h4>URLS</h4>
+                                                <div>
+                                                    <xforms:input ref="url">
+                                                        <xforms:label>Public Site</xforms:label>
+                                                        <xforms:alert>Required, must be a URL</xforms:alert>
+                                                        <xforms:action ev:event="xforms-value-changed">
+                                                            <xforms:var name="uri" select="." />
+                                                            <xforms:setvalue ref="instance('config-template')/uri_space" value="concat($uri, 'id/')" />
+                                                        </xforms:action>
+                                                    </xforms:input>
+                                                </div>
+                                                <div>
+                                                    <xforms:input ref="solr_published">
+                                                        <xforms:label>Solr Published</xforms:label>
+                                                        <xforms:alert>Required, must be a URL</xforms:alert>
+                                                        <xforms:hint>Unlikely to need changing.</xforms:hint>
+                                                    </xforms:input>
+                                                </div>
+                                            </xforms:group>
+                                            <xforms:trigger>
+                                                <xforms:label>Cancel</xforms:label>
+                                                <xforms:action ev:event="DOMActivate">
+                                                    <xforms:delete nodeset="instance('collections-list')/collection[last()]" />
+                                                    <xforms:toggle case="collections-list-interface" />
+                                                </xforms:action>
+                                            </xforms:trigger>
+                                            <xforms:trigger bind="create-collection-trigger">
+                                                <xforms:label>Create</xforms:label>
+                                                <xforms:action ev:event="DOMActivate">
+                                                    <!-- save collections list, config, and XQL files -->
+                                                    <xforms:send submission="save-collections" />
+                                                    <xforms:action ev:event="xforms-submit-done">
+                                                        <xforms:setvalue ref="instance('control-instance')/status">Collection successfully created in eXist-db.
+                                                        </xforms:setvalue>
+                                                        <xforms:setvalue ref="instance('control-instance')/collection-name" value="instance('collections-list')/collection[last()]/@name" />
+                                                        <xforms:send submission="save-config" />
+                                                    </xforms:action>
+                                                    <xforms:toggle case="collections-list-interface" />
+                                                </xforms:action>
+                                            </xforms:trigger>
+                                        </div>
+                                    </div>
+                                </xforms:case>
+                            </xforms:switch>
+                        </div>
+                    </xforms:case>
+                    <xforms:case id="numishare-editor">
+                        <div id="form">
+
+                            <xforms:group ref=".[xxforms:is-user-in-role('numishare-admin')]">
+                                <div>
+                                    <xforms:trigger appearance="minimal">
+                                        <xforms:label><span class="glyphicon glyphicon-arrow-left"></span> Return to Collections List</xforms:label>
+                                        <xforms:action ev:event="DOMActivate">
+                                            <!-- clear session attributes -->
+                                            <xforms:setvalue ref="instance('control-instance')/collection-name" />
+                                            <xforms:insert context="." origin="xxforms:set-session-attribute('collection-name', '')" />
+                                            <!-- get collection metadata -->
+                                            <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='collection-metadata'], '%SEQUENCE%', string-join(instance('collections-list')/collection/@name, ','))" />
+                                            <xforms:send submission="xquery-db" />
+                                            <xforms:action ev:event="xforms-submit-done">
+                                                <xforms:toggle case="numishare-admin" />
+                                            </xforms:action>
+                                        </xforms:action>
+                                    </xforms:trigger>
+                                </div>
+                            </xforms:group>
+                            <xforms:group ref=".[instance('control-instance')/status/text()]">
+                                <div class="alert alert-box alert-success">
+                                    <p><span class="glyphicon glyphicon-info-sign"></span>
+                                        <strong>Status:</strong>
+                                        <xforms:output ref="instance('control-instance')/status" />
+                                    </p>
+                                </div>
+                            </xforms:group>
+
+                            <xforms:switch>
+                                <xforms:case id="collection-interface">
+                                    <h2>Object Management</h2>
+                                    <ul>
+                                        <li>
+                                            <a href="edit/coin/">Create New Coin or Medal</a>
+                                        </li>
+                                        <!--<li>
 										<a href="edit/object/">Create New Non-Coin Object</a>
 									</li>-->
-										</ul>
-										<h2>Publication</h2>
-										<ul>
-										  <li>
-										    <xforms:trigger appearance="minimal">
-										      <xforms:label>Put them in 3store</xforms:label>
-										      <xforms:dispatch target="publish-3store-dialog" name="fr-show" ev:event="DOMActivate"/>
-										    </xforms:trigger>
-										  </li>
-											<li>
-												<xforms:trigger appearance="minimal">
-													<xforms:label>Publish All Approved Objects</xforms:label>
-													<xforms:dispatch target="publish-all-dialog" name="fr-show" ev:event="DOMActivate"/>
-												</xforms:trigger>
-											</li>
-											<li>
-												<xforms:trigger appearance="minimal">
-													<xforms:label>Reindex Published Objects</xforms:label>
-													<xforms:dispatch target="republish-dialog" name="fr-show" ev:event="DOMActivate"/>
-												</xforms:trigger>
-											</li>
-											<li>
-												<xforms:trigger appearance="minimal">
-													<xforms:label>Unpublish All Objects</xforms:label>
-													<xforms:dispatch target="unpublish-all" name="fr-show" ev:event="DOMActivate"/>
-												</xforms:trigger>
-											</li>
-										</ul>
-										<!-- search -->
-										<xforms:group ref="instance('control-instance')[number(numFound) &gt; 0]">
-											<div>
-												<h3>Search</h3>
-												<xforms:input ref="query_input"/>
-												<xforms:trigger>
-													<xforms:label>Search</xforms:label>
-													<xforms:action ev:event="DOMActivate">
-														<xforms:setvalue ref="instance('control-instance')/query_sent"
-															value="instance('control-instance')/query_input"/>
-														<xforms:setvalue ref="instance('eXist-xquery')/exist:text"
-															value="replace(instance('xqueries')/query[@id='query-objects'], 'QUERY', instance('control-instance')/query_sent)"/>
-														<xforms:send submission="xquery-pagination"/>
-													</xforms:action>
-												</xforms:trigger>
-												<xforms:group ref=".[string(query_sent)]">
-													<xforms:trigger>
-														<xforms:label>Clear</xforms:label>
-														<xforms:action ev:event="DOMActivate">
-															<!-- clear queries-->
-															<xforms:setvalue ref="instance('control-instance')/query_input"/>
-															<xforms:setvalue ref="instance('control-instance')/query_sent"/>
-															<!-- re-establish pagination query on page 1 -->
-															<xforms:setvalue ref="instance('control-instance')/page" value="1"/>
-															<xforms:setvalue ref="instance('eXist-xquery')/exist:text"
-																value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')"/>
-															<xforms:send submission="xquery-pagination"/>
-														</xforms:action>
-													</xforms:trigger>
-												</xforms:group>
-											</div>
-										</xforms:group>
-										<xforms:group ref="instance('pagination-result')">
-											<xforms:group ref=".[count(//record) &gt; 0]">
-												<h3>List of Objects</h3>
-												<!-- pagination variables -->
-												<xforms:var name="numFound" select="number(instance('control-instance')/numFound)"/>
-												<xforms:var name="page" select="number(instance('control-instance')/page)"/>
-												<xforms:var name="current" select="$page"/>
-												<xforms:var name="rows" select="number(20)"/>
-												<xforms:var name="start" select="(($page - 1) * 20) + 1"/>
-												<xforms:var name="end" select="if ($numFound &lt; $page * 20) then $numFound else $page * 20"/>
-												<xforms:var name="next" select="($page * 20) + 1"/>
-												<xforms:var name="total" select="ceiling($numFound div 20)"/>
-												<!-- pagination -->
-												<xforms:group ref=".[string-length(instance('control-instance')/query_sent) = 0]">
-													<!-- pagination -->
-													<div class="paging_div row">
-														<div class="col-md-6"> Displaying records <b>
+                                    </ul>
+                                    <h2>Publication</h2>
+                                    <ul>
+                                        <li>
+                                            <xforms:trigger appearance="minimal">
+                                                <xforms:label>Put them in 3store</xforms:label>
+                                                <xforms:dispatch target="publish-3store-dialog" name="fr-show" ev:event="DOMActivate" />
+                                            </xforms:trigger>
+                                        </li>
+                                        <li>
+                                            <xforms:trigger appearance="minimal">
+                                                <xforms:label>Publish All Approved Objects</xforms:label>
+                                                <xforms:dispatch target="publish-all-dialog" name="fr-show" ev:event="DOMActivate" />
+                                            </xforms:trigger>
+                                        </li>
+                                        <li>
+                                            <xforms:trigger appearance="minimal">
+                                                <xforms:label>Reindex Published Objects</xforms:label>
+                                                <xforms:dispatch target="republish-dialog" name="fr-show" ev:event="DOMActivate" />
+                                            </xforms:trigger>
+                                        </li>
+                                        <li>
+                                            <xforms:trigger appearance="minimal">
+                                                <xforms:label>Unpublish All Objects</xforms:label>
+                                                <xforms:dispatch target="unpublish-all" name="fr-show" ev:event="DOMActivate" />
+                                            </xforms:trigger>
+                                        </li>
+                                    </ul>
+                                    <!-- search -->
+                                    <xforms:group ref="instance('control-instance')[number(numFound) &gt; 0]">
+                                        <div>
+                                            <h3>Search</h3>
+                                            <xforms:input ref="query_input" />
+                                            <xforms:trigger>
+                                                <xforms:label>Search</xforms:label>
+                                                <xforms:action ev:event="DOMActivate">
+                                                    <xforms:setvalue ref="instance('control-instance')/query_sent" value="instance('control-instance')/query_input" />
+                                                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='query-objects'], 'QUERY', instance('control-instance')/query_sent)" />
+                                                    <xforms:send submission="xquery-pagination" />
+                                                </xforms:action>
+                                            </xforms:trigger>
+                                            <xforms:group ref=".[string(query_sent)]">
+                                                <xforms:trigger>
+                                                    <xforms:label>Clear</xforms:label>
+                                                    <xforms:action ev:event="DOMActivate">
+                                                        <!-- clear queries-->
+                                                        <xforms:setvalue ref="instance('control-instance')/query_input" />
+                                                        <xforms:setvalue ref="instance('control-instance')/query_sent" />
+                                                        <!-- re-establish pagination query on page 1 -->
+                                                        <xforms:setvalue ref="instance('control-instance')/page" value="1" />
+                                                        <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')" />
+                                                        <xforms:send submission="xquery-pagination" />
+                                                    </xforms:action>
+                                                </xforms:trigger>
+                                            </xforms:group>
+                                        </div>
+                                    </xforms:group>
+                                    <xforms:group ref="instance('pagination-result')">
+                                        <xforms:group ref=".[count(//record) &gt; 0]">
+                                            <h3>List of Objects</h3>
+                                            <!-- pagination variables -->
+                                            <xforms:var name="numFound" select="number(instance('control-instance')/numFound)" />
+                                            <xforms:var name="page" select="number(instance('control-instance')/page)" />
+                                            <xforms:var name="current" select="$page" />
+                                            <xforms:var name="rows" select="number(20)" />
+                                            <xforms:var name="start" select="(($page - 1) * 20) + 1" />
+                                            <xforms:var name="end" select="if ($numFound &lt; $page * 20) then $numFound else $page * 20" />
+                                            <xforms:var name="next" select="($page * 20) + 1" />
+                                            <xforms:var name="total" select="ceiling($numFound div 20)" />
+                                            <!-- pagination -->
+                                            <xforms:group ref=".[string-length(instance('control-instance')/query_sent) = 0]">
+                                                <!-- pagination -->
+                                                <div class="paging_div row">
+                                                    <div class="col-md-6"> Displaying records <b>
 																<xforms:output value="(($page - 1) * $rows) + 1"/>
 															</b> to <b>
 																<xforms:output value="if ($numFound &gt; $page * $rows) then $page * $rows else $numFound"/>
 															</b> of <b>
 																<xforms:output value="$numFound"/>
 															</b> total results.</div>
-														<div class="col-md-6 text-right">
-															<!-- previous -->
-															<xforms:group ref=".[$page &gt; 1]">
-																<xforms:trigger>
-																	<xforms:label><span class="glyphicon glyphicon-fast-backward"></span></xforms:label>
-																	<xforms:action ev:event="DOMActivate">
-																		<xforms:setvalue ref="instance('control-instance')/page" value="1"/>
-																		<xforms:setvalue ref="instance('eXist-xquery')/exist:text"
-																			value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')"/>
-																		<xforms:send submission="xquery-pagination"/>
-																	</xforms:action>
-																</xforms:trigger>
-																<xforms:trigger>
-																	<xforms:label><span class="glyphicon glyphicon-backward"></span></xforms:label>
-																	<xforms:action ev:event="DOMActivate">
-																		<xforms:setvalue ref="instance('control-instance')/page" value="$page - 1"/>
-																		<xforms:setvalue ref="instance('eXist-xquery')/exist:text"
-																			value="replace(instance('xqueries')/query[@id='get-objects'], 'START', string($start - 20))"/>
-																		<xforms:send submission="xquery-pagination"/>
-																	</xforms:action>
-																</xforms:trigger>
-															</xforms:group>
-															<xforms:group ref=".[$page = 1]">
-																<a class="btn btn-default disabled" title="First" href="#">
-																	<span class="glyphicon glyphicon-fast-backward"></span>
-																</a>
-																<a class="btn btn-default disabled" title="Previous" href="#">
-																	<span class="glyphicon glyphicon-backward"></span>
-																</a>
-															</xforms:group>
-															<!-- current-->
-															<button type="button" class="btn btn-default">
+                                                    <div class="col-md-6 text-right">
+                                                        <!-- previous -->
+                                                        <xforms:group ref=".[$page &gt; 1]">
+                                                            <xforms:trigger>
+                                                                <xforms:label><span class="glyphicon glyphicon-fast-backward"></span></xforms:label>
+                                                                <xforms:action ev:event="DOMActivate">
+                                                                    <xforms:setvalue ref="instance('control-instance')/page" value="1" />
+                                                                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')" />
+                                                                    <xforms:send submission="xquery-pagination" />
+                                                                </xforms:action>
+                                                            </xforms:trigger>
+                                                            <xforms:trigger>
+                                                                <xforms:label><span class="glyphicon glyphicon-backward"></span></xforms:label>
+                                                                <xforms:action ev:event="DOMActivate">
+                                                                    <xforms:setvalue ref="instance('control-instance')/page" value="$page - 1" />
+                                                                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', string($start - 20))" />
+                                                                    <xforms:send submission="xquery-pagination" />
+                                                                </xforms:action>
+                                                            </xforms:trigger>
+                                                        </xforms:group>
+                                                        <xforms:group ref=".[$page = 1]">
+                                                            <a class="btn btn-default disabled" title="First" href="#">
+                                                                <span class="glyphicon glyphicon-fast-backward"></span>
+                                                            </a>
+                                                            <a class="btn btn-default disabled" title="Previous" href="#">
+                                                                <span class="glyphicon glyphicon-backward"></span>
+                                                            </a>
+                                                        </xforms:group>
+                                                        <!-- current-->
+                                                        <button type="button" class="btn btn-default">
 																<b>
 																	<xforms:output value="$current"/>
 																</b>
 															</button>
-															<!-- next -->
-															<xforms:group ref=".[$total &gt; $current]">
-																<xforms:trigger>
-																	<xforms:label><span class="glyphicon glyphicon-forward"></span></xforms:label>
-																	<xforms:action ev:event="DOMActivate">
-																		<xforms:setvalue ref="instance('control-instance')/page" value="$page + 1"/>
-																		<xforms:setvalue ref="instance('eXist-xquery')/exist:text"
-																			value="replace(instance('xqueries')/query[@id='get-objects'], 'START', string($next))"/>
-																		<xforms:send submission="xquery-pagination"/>
-																	</xforms:action>
-																</xforms:trigger>
-																<xforms:trigger>
-																	<xforms:label>
-																		<span class="glyphicon glyphicon-fast-forward"></span>
-																	</xforms:label>
-																	<xforms:action ev:event="DOMActivate">
-																		<xforms:setvalue ref="instance('control-instance')/page" value="$total"/>
-																		<xforms:setvalue ref="instance('eXist-xquery')/exist:text"
-																			value="replace(instance('xqueries')/query[@id='get-objects'], 'START', string((($total - 1) * 20) + 1))"/>
-																		<xforms:send submission="xquery-pagination"/>
-																	</xforms:action>
-																</xforms:trigger>
-															</xforms:group>
-															<xforms:group ref=".[not($total &gt; $current)]">
-																<a class="btn btn-default disabled" title="Next" href="#">
-																	<span class="glyphicon glyphicon-forward"></span>
-																</a>
-																<a class="btn btn-default disabled" href="#">
-																	<span class="glyphicon glyphicon-fast-forward"></span>
-																</a>
-															</xforms:group>
-														</div>
-													</div>
-												</xforms:group>
-												<table class="table">
-													<thead>
-														<tr>
-															<th style="width:5%">Type</th>
-															<th>Title</th>
-															<th style="width:10%">View</th>
-															<th style="width:5%">Publish</th>
-															<th style="width:5%">Delete</th>
-														</tr>
-													</thead>
-													<tbody>
-														<xforms:repeat nodeset="instance('pagination-result')//record">
-															<xforms:var name="id" select="id"/>
-															<tr>
-																<td class="text-center">
-																	<xforms:output ref="type"/>
-																</td>
-																<td>
-																	<h4>
-																		<xforms:group ref=".[type='nuds']">
-																			<xforms:trigger appearance="minimal">
-																				<xforms:label value="concat(title, ' (', $id, ')')"/>
-																				<xforms:action ev:event="DOMActivate">
-																				<xforms:load show="replace" resource="edit/coin/?id={$id}"/>
-																				</xforms:action>
-																			</xforms:trigger>
-																		</xforms:group>
-																		<xforms:group ref=".[type!='nuds']">
-																			<xforms:output ref="title"/>
-																			<xforms:output ref="concat('(', $id, ')')"/>
-																		</xforms:group>
-																	</h4>
-																	<div>
-																		<xforms:output ref="maintenanceStatus">
-																			<xforms:label>Status</xforms:label>
-																		</xforms:output>
-																	</div>
-																	<xforms:group ref="recordType">
-																		<div>
-																			<xforms:output ref=".">
-																				<xforms:label>Record Type</xforms:label>
-																			</xforms:output>
-																		</div>
-																	</xforms:group>
-																	<xforms:group ref="obverse">
-																		<div>
-																			<xforms:output ref=".">
-																				<xforms:label>Obverse</xforms:label>
-																			</xforms:output>
-																		</div>
-																	</xforms:group>
-																	<xforms:group ref="reverse">
-																		<div>
-																			<xforms:output ref=".">
-																				<xforms:label>Reverse</xforms:label>
-																			</xforms:output>
-																		</div>
-																	</xforms:group>
-																</td>
-																<td class="text-center">
-																	<a href="{instance('config')/url}id/{$id}.xml" target="_blank">xml</a> | <a
-																		href="{instance('config')/url}id/{$id}" target="_blank">html</a>
-																</td>
-																<td class="text-center">
-																	<!-- only enable publication if the maintenanceStatus allows it -->
-																	<xforms:group
-																		ref=".[maintenanceStatus='new' or maintenanceStatus='revised' or maintenanceStatus='derived']">
-																		<xforms:group ref="published[. = true()]">
-																			<xforms:trigger appearance="minimal">
-																				<xforms:label><span
-																				class="glyphicon glyphicon-{if (.=true()) then 'ok' else 'unchecked'}"
-																				></span></xforms:label>
-																				<xforms:action ev:event="DOMActivate">
-																				<xforms:var name="val" select="." as="xs:boolean"/>
-																				<xforms:setvalue ref="instance('control-instance')/id" value="$id"/>
-																				<!-- update publicationStatus -->
-																				<xforms:setvalue ref="instance('control-instance')/publicationStatus"
-																				>inProcess</xforms:setvalue>
-																				<xforms:send submission="load-object"/>
-																				<!-- delete from Solr -->
-																				<xforms:setvalue ref="instance('deleteId')/query"
-																				value="concat('recordId:&#x022;', instance('control-instance')/id, '&#x022;')"/>
-																				<xforms:send submission="delete-solr-doc"/>
-																				<xforms:setvalue ref="." value="false()"/>
-																				</xforms:action>
-																			</xforms:trigger>
-																		</xforms:group>
-																		<xforms:group ref="published[. = false()]">
-																			<xforms:trigger appearance="minimal">
-																				<xforms:label><span
-																				class="glyphicon glyphicon-{if (.=true()) then 'ok' else 'unchecked'}"
-																				></span></xforms:label>
-																				<xforms:action ev:event="DOMActivate">
-																				<xforms:var name="val" select="." as="xs:boolean"/>
-																				<!-- publish the record if the box is checked -->
-																				<xforms:setvalue ref="instance('control-instance')/id" value="$id"/>
-																				<xforms:setvalue ref="instance('control-instance')/publicationStatus"
-																				>approved</xforms:setvalue>
-																				<xforms:send submission="load-object"/>
-																				<!-- publish to solr -->
-																				<xforms:send submission="nuds-to-solr"/>
-																				<xforms:send submission="submit-commit"/>
-																				<xforms:setvalue ref="." value="true()"/>
-																				</xforms:action>
-																			</xforms:trigger>
-																		</xforms:group>
-																	</xforms:group>
-																</td>
-																<td class="text-center">
-																	<xforms:trigger appearance="minimal">
-																		<xforms:label>
-																			<span class="glyphicon glyphicon-remove"></span>
-																		</xforms:label>
-																		<xforms:action ev:event="DOMActivate">
-																			<xforms:setvalue ref="instance('control-instance')/id" value="$id"/>
-																			<xforms:dispatch target="delete" name="fr-show"/>
-																		</xforms:action>
-																	</xforms:trigger>
-																</td>
-															</tr>
-														</xforms:repeat>
-													</tbody>
-												</table>
-											</xforms:group>
-											<xforms:group ref=".[count(//record)=0]">
-												<h3>No objects in collection.</h3>
-											</xforms:group>
-										</xforms:group>
-									</xforms:case>
-									<xforms:case id="union_type_catalog">
-										<h2>Union Type Corpus</h2>
-										<p>This collection is configured as a union type corpus of the following type series:</p> <p>The XML collection is not
-											designed to store its own NUDS documents, but rather combines Solr and SPARQL queries from the designated series in
-											the Numishare config, pointing search/browse responses to the external corpus.</p>
-									</xforms:case>
-								</xforms:switch>
-							</div>
-						</xforms:case>
-					</xforms:switch>
-					<!--<fr:xforms-inspector/>-->
-				</div>
-			</div>
-		</div>
-		<!-- *********************** DIALOGS ********************* -->
-		<!-- ********* NUMISHARE-ADMIN ********* -->
-		<fr:alert-dialog id="delete-collection-dialog">
-			<fr:label>Delete Collection</fr:label>
-			<fr:message>Are you sure you want to delete this collection? This is irreversible. It is recommended that you make a backup first.</fr:message>
-			<fr:negative-choice>
-				<fr:label>No</fr:label>
-			</fr:negative-choice>
-			<fr:positive-choice>
-				<fr:label>Yes</fr:label>
-				<xforms:action ev:event="DOMActivate">
-					<!-- set and submit the XQuery -->
-					<xforms:setvalue ref="instance('eXist-xquery')/exist:text"
-						value="replace(instance('xqueries')/query[@id='delete-collection'], '%COLLECTION%', instance('control-instance')/collection-name)"/>
-					<xforms:send submission="xquery-db"/>
-					<!-- delete the collection from the collections-list XML -->
-					<xforms:delete nodeset="instance('collections-list')/collection[@name=instance('control-instance')/collection-name]"/>
-					<xforms:send submission="save-collections"/>
-					<!-- update status and get collection metadata -->
-					<xforms:action ev:event="xforms-submit-done">
-						<xforms:setvalue ref="instance('control-instance')/status">Collection successfully removed from eXist-db.</xforms:setvalue>
-						<xforms:setvalue ref="instance('eXist-xquery')/exist:text"
-							value="replace(instance('xqueries')/query[@id='collection-metadata'], '%SEQUENCE%', string-join(instance('collections-list')/collection/@name, ','))"/>
-						<xforms:send submission="xquery-db"/>
-						<!-- blank collection name -->
-						<xforms:setvalue ref="instance('control-instance')/collection-name"/>
-					</xforms:action>
-				</xforms:action>
-			</fr:positive-choice>
-		</fr:alert-dialog>
-		<!-- ********* NUMISHARE-EDITOR ********* -->
-		<fr:alert-dialog id="delete">
-			<fr:label>Delete</fr:label>
-			<fr:message>Are you sure you want to delete this object?</fr:message>
-			<fr:negative-choice>
-				<fr:label>No</fr:label>
-			</fr:negative-choice>
-			<fr:positive-choice>
-				<fr:label>Yes</fr:label>
-				<xforms:action ev:event="DOMActivate">
-					<xforms:send submission="delete-object"/>
-					<xforms:setvalue ref="instance('deleteId')/query" value="concat('recordId:&#x022;', instance('control-instance')/id, '&#x022;')"/>
-					<xforms:send submission="delete-solr-doc"/>
-					<!-- get new numCount -->
-					<xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="instance('xqueries')/query[@id='collection-count']"/>
-					<xforms:send submission="xquery-collection"/>
-					<!-- reload table -->
-					<xforms:var name="page" select="number(instance('control-instance')/page)"/>
-					<xforms:var name="start" select="(($page - 1) * 20) + 1"/>
-					<xforms:var name="end" select="$page * 20"/>
-					<xforms:setvalue ref="instance('eXist-xquery')/exist:text"
-						value="replace(instance('xqueries')/query[@id='get-objects'], 'START', string($start))"/>
-					<xforms:send submission="xquery-pagination"/>
-				</xforms:action>
-			</fr:positive-choice>
-		</fr:alert-dialog>
-		<!-- mass publication dialogs -->
-		<fr:alert-dialog id="publish-all-dialog">
-			<fr:label>Publish All</fr:label>
-			<fr:message>Do you want to publish all objects? This may take several minutes.</fr:message>
-			<fr:negative-choice>
-				<fr:label>No</fr:label>
-			</fr:negative-choice>
-			<fr:positive-choice>
-				<fr:label>Yes</fr:label>
-				<xforms:action ev:event="DOMActivate">
-					<xforms:var name="count" select="if (instance('config')/collection_type='hoard') then '25' else '100'"/>
-					<xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='publish-all'], 'COUNT', $count)"/>
-					<xforms:send submission="xquery-collection"/>
-					<xforms:action ev:event="xforms-submit-done">
-						<xforms:var name="tokens" select="tokenize(replace(instance('xquery-result')/report, ' ', ''), ',')"/>
-						<xforms:action xxforms:iterate="$tokens">
-							<xforms:setvalue ref="instance('control-instance')/identifiers" value="context()"/>
-							<!-- get Solr document -->
-							<xforms:send submission="generate-add-document"/>
-							<xforms:send submission="submit-commit"/>
-						</xforms:action>
-						<!-- reload table -->
-						<xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')"/>
-						<xforms:send submission="xquery-pagination"/>
-					</xforms:action>
-				</xforms:action>
-			</fr:positive-choice>
-		</fr:alert-dialog>
-		<fr:alert-dialog id="publish-3store-dialog">
-			<fr:label>Publish to Fueski</fr:label>
-			<fr:message>Do you want to publish to 3store? This may take several minutes.</fr:message>
-			<fr:negative-choice>
-				<fr:label>No</fr:label>
-			</fr:negative-choice>
-			<fr:positive-choice>
-			  <fr:label>Yes</fr:label>
-			  <xforms:send submission="post-to-3store"/>
-			</fr:positive-choice>
-		</fr:alert-dialog>
+                                                        <!-- next -->
+                                                        <xforms:group ref=".[$total &gt; $current]">
+                                                            <xforms:trigger>
+                                                                <xforms:label><span class="glyphicon glyphicon-forward"></span></xforms:label>
+                                                                <xforms:action ev:event="DOMActivate">
+                                                                    <xforms:setvalue ref="instance('control-instance')/page" value="$page + 1" />
+                                                                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', string($next))" />
+                                                                    <xforms:send submission="xquery-pagination" />
+                                                                </xforms:action>
+                                                            </xforms:trigger>
+                                                            <xforms:trigger>
+                                                                <xforms:label>
+                                                                    <span class="glyphicon glyphicon-fast-forward"></span>
+                                                                </xforms:label>
+                                                                <xforms:action ev:event="DOMActivate">
+                                                                    <xforms:setvalue ref="instance('control-instance')/page" value="$total" />
+                                                                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', string((($total - 1) * 20) + 1))" />
+                                                                    <xforms:send submission="xquery-pagination" />
+                                                                </xforms:action>
+                                                            </xforms:trigger>
+                                                        </xforms:group>
+                                                        <xforms:group ref=".[not($total &gt; $current)]">
+                                                            <a class="btn btn-default disabled" title="Next" href="#">
+                                                                <span class="glyphicon glyphicon-forward"></span>
+                                                            </a>
+                                                            <a class="btn btn-default disabled" href="#">
+                                                                <span class="glyphicon glyphicon-fast-forward"></span>
+                                                            </a>
+                                                        </xforms:group>
+                                                    </div>
+                                                </div>
+                                            </xforms:group>
+                                            <table class="table">
+                                                <thead>
+                                                    <tr>
+                                                        <th style="width:5%">Type</th>
+                                                        <th>Title</th>
+                                                        <th style="width:10%">View</th>
+                                                        <th style="width:5%">Publish</th>
+                                                        <th style="width:5%">Delete</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    <xforms:repeat nodeset="instance('pagination-result')//record">
+                                                        <xforms:var name="id" select="id" />
+                                                        <tr>
+                                                            <td class="text-center">
+                                                                <xforms:output ref="type" />
+                                                            </td>
+                                                            <td>
+                                                                <h4>
+                                                                    <xforms:group ref=".[type='nuds']">
+                                                                        <xforms:trigger appearance="minimal">
+                                                                            <xforms:label value="concat(title, ' (', $id, ')')" />
+                                                                            <xforms:action ev:event="DOMActivate">
+                                                                                <xforms:load show="replace" resource="edit/coin/?id={$id}" />
+                                                                            </xforms:action>
+                                                                        </xforms:trigger>
+                                                                    </xforms:group>
+                                                                    <xforms:group ref=".[type!='nuds']">
+                                                                        <xforms:output ref="title" />
+                                                                        <xforms:output ref="concat('(', $id, ')')" />
+                                                                    </xforms:group>
+                                                                </h4>
+                                                                <div>
+                                                                    <xforms:output ref="maintenanceStatus">
+                                                                        <xforms:label>Status</xforms:label>
+                                                                    </xforms:output>
+                                                                </div>
+                                                                <xforms:group ref="recordType">
+                                                                    <div>
+                                                                        <xforms:output ref=".">
+                                                                            <xforms:label>Record Type</xforms:label>
+                                                                        </xforms:output>
+                                                                    </div>
+                                                                </xforms:group>
+                                                                <xforms:group ref="obverse">
+                                                                    <div>
+                                                                        <xforms:output ref=".">
+                                                                            <xforms:label>Obverse</xforms:label>
+                                                                        </xforms:output>
+                                                                    </div>
+                                                                </xforms:group>
+                                                                <xforms:group ref="reverse">
+                                                                    <div>
+                                                                        <xforms:output ref=".">
+                                                                            <xforms:label>Reverse</xforms:label>
+                                                                        </xforms:output>
+                                                                    </div>
+                                                                </xforms:group>
+                                                            </td>
+                                                            <td class="text-center">
+                                                                <a href="{instance('config')/url}id/{$id}.xml" target="_blank">xml</a> | <a href="{instance('config')/url}id/{$id}" target="_blank">html</a>
+                                                            </td>
+                                                            <td class="text-center">
+                                                                <!-- only enable publication if the maintenanceStatus allows it -->
+                                                                <xforms:group ref=".[maintenanceStatus='new' or maintenanceStatus='revised' or maintenanceStatus='derived']">
+                                                                    <xforms:group ref="published[. = true()]">
+                                                                        <xforms:trigger appearance="minimal">
+                                                                            <xforms:label><span class="glyphicon glyphicon-{if (.=true()) then 'ok' else 'unchecked'}"></span></xforms:label>
+                                                                            <xforms:action ev:event="DOMActivate">
+                                                                                <xforms:var name="val" select="." as="xs:boolean" />
+                                                                                <xforms:setvalue ref="instance('control-instance')/id" value="$id" />
+                                                                                <!-- update publicationStatus -->
+                                                                                <xforms:setvalue ref="instance('control-instance')/publicationStatus">inProcess</xforms:setvalue>
+                                                                                <xforms:send submission="load-object" />
+                                                                                <!-- delete from Solr -->
+                                                                                <xforms:setvalue ref="instance('deleteId')/query" value="concat('recordId:&#x022;', instance('control-instance')/id, '&#x022;')" />
+                                                                                <xforms:send submission="delete-solr-doc" />
+                                                                                <xforms:setvalue ref="." value="false()" />
+                                                                            </xforms:action>
+                                                                        </xforms:trigger>
+                                                                    </xforms:group>
+                                                                    <xforms:group ref="published[. = false()]">
+                                                                        <xforms:trigger appearance="minimal">
+                                                                            <xforms:label><span class="glyphicon glyphicon-{if (.=true()) then 'ok' else 'unchecked'}"></span></xforms:label>
+                                                                            <xforms:action ev:event="DOMActivate">
+                                                                                <xforms:var name="val" select="." as="xs:boolean" />
+                                                                                <!-- publish the record if the box is checked -->
+                                                                                <xforms:setvalue ref="instance('control-instance')/id" value="$id" />
+                                                                                <xforms:setvalue ref="instance('control-instance')/publicationStatus">approved</xforms:setvalue>
+                                                                                <xforms:send submission="load-object" />
+                                                                                <!-- publish to solr -->
+                                                                                <xforms:send submission="nuds-to-solr" />
+                                                                                <xforms:send submission="submit-commit" />
+                                                                                <xforms:setvalue ref="." value="true()" />
+                                                                            </xforms:action>
+                                                                        </xforms:trigger>
+                                                                    </xforms:group>
+                                                                </xforms:group>
+                                                            </td>
+                                                            <td class="text-center">
+                                                                <xforms:trigger appearance="minimal">
+                                                                    <xforms:label>
+                                                                        <span class="glyphicon glyphicon-remove"></span>
+                                                                    </xforms:label>
+                                                                    <xforms:action ev:event="DOMActivate">
+                                                                        <xforms:setvalue ref="instance('control-instance')/id" value="$id" />
+                                                                        <xforms:dispatch target="delete" name="fr-show" />
+                                                                    </xforms:action>
+                                                                </xforms:trigger>
+                                                            </td>
+                                                        </tr>
+                                                    </xforms:repeat>
+                                                </tbody>
+                                            </table>
+                                        </xforms:group>
+                                        <xforms:group ref=".[count(//record)=0]">
+                                            <h3>No objects in collection.</h3>
+                                        </xforms:group>
+                                    </xforms:group>
+                                </xforms:case>
+                                <xforms:case id="union_type_catalog">
+                                    <h2>Union Type Corpus</h2>
+                                    <p>This collection is configured as a union type corpus of the following type series:</p>
+                                    <p>The XML collection is not designed to store its own NUDS documents, but rather combines Solr and SPARQL queries from the designated series in the Numishare config, pointing search/browse responses to the external corpus.</p>
+                                </xforms:case>
+                            </xforms:switch>
+                        </div>
+                    </xforms:case>
+                </xforms:switch>
+                <!--<fr:xforms-inspector/>-->
+            </div>
+        </div>
+    </div>
+    <!-- *********************** DIALOGS ********************* -->
+    <!-- ********* NUMISHARE-ADMIN ********* -->
+    <fr:alert-dialog id="delete-collection-dialog">
+        <fr:label>Delete Collection</fr:label>
+        <fr:message>Are you sure you want to delete this collection? This is irreversible. It is recommended that you make a backup first.</fr:message>
+        <fr:negative-choice>
+            <fr:label>No</fr:label>
+        </fr:negative-choice>
+        <fr:positive-choice>
+            <fr:label>Yes</fr:label>
+            <xforms:action ev:event="DOMActivate">
+                <!-- set and submit the XQuery -->
+                <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='delete-collection'], '%COLLECTION%', instance('control-instance')/collection-name)" />
+                <xforms:send submission="xquery-db" />
+                <!-- delete the collection from the collections-list XML -->
+                <xforms:delete nodeset="instance('collections-list')/collection[@name=instance('control-instance')/collection-name]" />
+                <xforms:send submission="save-collections" />
+                <!-- update status and get collection metadata -->
+                <xforms:action ev:event="xforms-submit-done">
+                    <xforms:setvalue ref="instance('control-instance')/status">Collection successfully removed from eXist-db.</xforms:setvalue>
+                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='collection-metadata'], '%SEQUENCE%', string-join(instance('collections-list')/collection/@name, ','))" />
+                    <xforms:send submission="xquery-db" />
+                    <!-- blank collection name -->
+                    <xforms:setvalue ref="instance('control-instance')/collection-name" />
+                </xforms:action>
+            </xforms:action>
+        </fr:positive-choice>
+    </fr:alert-dialog>
+    <!-- ********* NUMISHARE-EDITOR ********* -->
+    <fr:alert-dialog id="delete">
+        <fr:label>Delete</fr:label>
+        <fr:message>Are you sure you want to delete this object?</fr:message>
+        <fr:negative-choice>
+            <fr:label>No</fr:label>
+        </fr:negative-choice>
+        <fr:positive-choice>
+            <fr:label>Yes</fr:label>
+            <xforms:action ev:event="DOMActivate">
+                <xforms:send submission="delete-object" />
+                <xforms:setvalue ref="instance('deleteId')/query" value="concat('recordId:&#x022;', instance('control-instance')/id, '&#x022;')" />
+                <xforms:send submission="delete-solr-doc" />
+                <!-- get new numCount -->
+                <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="instance('xqueries')/query[@id='collection-count']" />
+                <xforms:send submission="xquery-collection" />
+                <!-- reload table -->
+                <xforms:var name="page" select="number(instance('control-instance')/page)" />
+                <xforms:var name="start" select="(($page - 1) * 20) + 1" />
+                <xforms:var name="end" select="$page * 20" />
+                <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', string($start))" />
+                <xforms:send submission="xquery-pagination" />
+            </xforms:action>
+        </fr:positive-choice>
+    </fr:alert-dialog>
+    <!-- mass publication dialogs -->
+    <fr:alert-dialog id="publish-all-dialog">
+        <fr:label>Publish All</fr:label>
+        <fr:message>Do you want to publish all objects? This may take several minutes.</fr:message>
+        <fr:negative-choice>
+            <fr:label>No</fr:label>
+        </fr:negative-choice>
+        <fr:positive-choice>
+            <fr:label>Yes</fr:label>
+            <xforms:action ev:event="DOMActivate">
+                <xforms:var name="count" select="if (instance('config')/collection_type='hoard') then '25' else '100'" />
+                <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='publish-all'], 'COUNT', $count)" />
+                <xforms:send submission="xquery-collection" />
+                <xforms:action ev:event="xforms-submit-done">
+                    <xforms:var name="tokens" select="tokenize(replace(instance('xquery-result')/report, ' ', ''), ',')" />
+                    <xforms:action xxforms:iterate="$tokens">
+                        <xforms:setvalue ref="instance('control-instance')/identifiers" value="context()" />
+                        <!-- get Solr document -->
+                        <xforms:send submission="generate-add-document" />
+                        <xforms:send submission="submit-commit" />
+                    </xforms:action>
+                    <!-- reload table -->
+                    <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')" />
+                    <xforms:send submission="xquery-pagination" />
+                </xforms:action>
+            </xforms:action>
+        </fr:positive-choice>
+    </fr:alert-dialog>
+    <fr:alert-dialog id="publish-3store-dialog">
+        <fr:label>Publish to Fueski</fr:label>
+        <fr:message>Do you want to publish to 3store? This may take several minutes.</fr:message>
+        <fr:negative-choice>
+            <fr:label>No</fr:label>
+        </fr:negative-choice>
+        <fr:positive-choice>
+            <fr:label>Yes</fr:label>
+            <xforms:action ev:event="DOMActivate">
+                <xforms:send submission="post-to-3store" />
+            </xforms:action>
+        </fr:positive-choice>
+    </fr:alert-dialog>
 
-		<fr:alert-dialog id="unpublish-all">
-			<fr:label>Unpublish All</fr:label>
-			<fr:message>Do you want to unpublish all objects?</fr:message>
-			<fr:negative-choice>
-				<fr:label>No</fr:label>
-			</fr:negative-choice>
-			<fr:positive-choice>
-				<fr:label>Yes</fr:label>
-				<xforms:action ev:event="DOMActivate">
-					<xforms:setvalue ref="instance('deleteAll')/query" value="concat('collection-name:', instance('control-instance')/collection-name)"/>
-					<xforms:send submission="delete-all"/>
-					<!-- optimize index -->
-					<!--<xforms:send submission="optimize"></xforms:send>-->
-					<!-- reload table -->
-					<xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')"/>
-					<xforms:send submission="xquery-pagination"/>
-				</xforms:action>
-			</fr:positive-choice>
-		</fr:alert-dialog>
-		<fr:alert-dialog id="republish-dialog">
-			<fr:label>Republish</fr:label>
-			<fr:message>Do you want to reindex currently published objects?</fr:message>
-			<fr:negative-choice>
-				<fr:label>No</fr:label>
-			</fr:negative-choice>
-			<fr:positive-choice>
-				<fr:label>Yes</fr:label>
-				<xforms:action ev:event="DOMActivate">
-					<xforms:send submission="republish"/>
-					<xforms:send submission="optimize" ev:event="xforms-submit-done"/>
-				</xforms:action>
-			</fr:positive-choice>
-		</fr:alert-dialog>
-	</body>
+    <fr:alert-dialog id="unpublish-all">
+        <fr:label>Unpublish All</fr:label>
+        <fr:message>Do you want to unpublish all objects?</fr:message>
+        <fr:negative-choice>
+            <fr:label>No</fr:label>
+        </fr:negative-choice>
+        <fr:positive-choice>
+            <fr:label>Yes</fr:label>
+            <xforms:action ev:event="DOMActivate">
+                <xforms:setvalue ref="instance('deleteAll')/query" value="concat('collection-name:', instance('control-instance')/collection-name)" />
+                <xforms:send submission="delete-all" />
+                <!-- optimize index -->
+                <!--<xforms:send submission="optimize"></xforms:send>-->
+                <!-- reload table -->
+                <xforms:setvalue ref="instance('eXist-xquery')/exist:text" value="replace(instance('xqueries')/query[@id='get-objects'], 'START', '1')" />
+                <xforms:send submission="xquery-pagination" />
+            </xforms:action>
+        </fr:positive-choice>
+    </fr:alert-dialog>
+    <fr:alert-dialog id="republish-dialog">
+        <fr:label>Republish</fr:label>
+        <fr:message>Do you want to reindex currently published objects?</fr:message>
+        <fr:negative-choice>
+            <fr:label>No</fr:label>
+        </fr:negative-choice>
+        <fr:positive-choice>
+            <fr:label>Yes</fr:label>
+            <xforms:action ev:event="DOMActivate">
+                <xforms:send submission="republish" />
+                <xforms:send submission="optimize" ev:event="xforms-submit-done" />
+            </xforms:action>
+        </fr:positive-choice>
+    </fr:alert-dialog>
+</body>
+
 </html>

--- a/xforms/xquery/delete-from-3store.xq
+++ b/xforms/xquery/delete-from-3store.xq
@@ -1,0 +1,45 @@
+xquery version "3.1";
+
+declare namespace exist = "http://exist.sourceforge.net/NS/exist";
+declare namespace httpclient = "http://exist-db.org/xquery/httpclient";
+
+import module namespace request = "http://exist-db.org/xquery/request";
+(: import module namespace hc = "http://expath.org/ns/http-client"; :)
+
+let $recordId := request:get-parameter("recordId", ())
+
+let $collection := replace(request:get-effective-uri(), "^/.*/db/(.*)/.*$", "/db/$1")
+
+(: use update for deleting triples :)
+let $sparql_endpoint := concat(replace(collection($collection)/config/sparql_endpoint, "/query$", ""),"/update")
+(: only http requests can be made :)
+let $sparql_endpoint := xs:anyURI(replace($sparql_endpoint,"https","http"))
+
+let $uri_space := xs:anyURI(collection($collection)/config/uri_space)
+
+let $update := encode-for-uri("DELETE WHERE {<" || $uri_space || $recordId || "> ?p ?o}")
+
+(:
+let $request :=
+    <hc:request method="post"
+                href="http://localhost:8080/fuseki/testcoins/update"
+                username="admin"
+                password="admin"
+               auth-method="basic">
+           <hc:header name="Cache-Control" value="no-cache" />
+           <hc:body media-type="text/plain" method="text">{ $update }</hc:body>
+   </hc:request>
+
+
+let $response := hc:send-request($request)
+return $response[1]
+:)
+
+let $headers :=
+    <httpclient:headers>
+            <httpclient:header name="Content-Type" value="application/x-www-form-urlencoded"/>
+            <httpclient:header name="media-type" value="application/x-www-form-urlencoded"/>
+   </httpclient:headers>
+
+let $response := httpclient:post($sparql_endpoint, "update=" || $update, false(), $headers)
+return $response

--- a/xforms/xquery/delete-from-3store.xq
+++ b/xforms/xquery/delete-from-3store.xq
@@ -2,6 +2,7 @@ xquery version "3.1";
 
 declare namespace exist = "http://exist.sourceforge.net/NS/exist";
 declare namespace httpclient = "http://exist-db.org/xquery/httpclient";
+declare namespace nuds = "http://nomisma.org/nuds";
 
 import module namespace request = "http://exist-db.org/xquery/request";
 (: import module namespace hc = "http://expath.org/ns/http-client"; :)
@@ -10,36 +11,31 @@ let $recordId := request:get-parameter("recordId", ())
 
 let $collection := replace(request:get-effective-uri(), "^/.*/db/(.*)/.*$", "/db/$1")
 
+
+let $recordIds :=
+    if (request:get-parameter("recordId", ())) then
+       request:get-parameter("recordId", ())
+    else
+       for $object in
+            collection($collection)/nuds:nuds[nuds:control/nuds:publicationStatus = 'approved']
+       return $object/nuds:control/nuds:recordId/text()
+
 (: use update for deleting triples :)
 let $sparql_endpoint := concat(replace(collection($collection)/config/sparql_endpoint, "/query$", ""),"/update")
 (: only http requests can be made :)
 let $sparql_endpoint := xs:anyURI(replace($sparql_endpoint,"https","http"))
 
 let $uri_space := xs:anyURI(collection($collection)/config/uri_space)
-
-let $update := encode-for-uri("DELETE WHERE {<" || $uri_space || $recordId || "> ?p ?o}")
-
-(:
-let $request :=
-    <hc:request method="post"
-                href="http://localhost:8080/fuseki/testcoins/update"
-                username="admin"
-                password="admin"
-               auth-method="basic">
-           <hc:header name="Cache-Control" value="no-cache" />
-           <hc:body media-type="text/plain" method="text">{ $update }</hc:body>
-   </hc:request>
-
-
-let $response := hc:send-request($request)
-return $response[1]
-:)
-
 let $headers :=
     <httpclient:headers>
-            <httpclient:header name="Content-Type" value="application/x-www-form-urlencoded"/>
-            <httpclient:header name="media-type" value="application/x-www-form-urlencoded"/>
-   </httpclient:headers>
+      <httpclient:header name="Content-Type" value="application/x-www-form-urlencoded"/>
+      <httpclient:header name="media-type" value="application/x-www-form-urlencoded"/>
+    </httpclient:headers>
 
-let $response := httpclient:post($sparql_endpoint, "update=" || $update, false(), $headers)
-return $response
+let $responses :=
+    for $recordId in $recordIds
+            let $update := encode-for-uri("DELETE WHERE {<" || $uri_space || $recordId || "> ?p ?o}")
+	    let $response := httpclient:post($sparql_endpoint, "update=" || $update, false(), $headers)
+    return $response
+return <result>{$responses}</result>
+	

--- a/xforms/xquery/post-to-3store.xq
+++ b/xforms/xquery/post-to-3store.xq
@@ -4,22 +4,20 @@ declare namespace exist = "http://exist.sourceforge.net/NS/exist";
 declare namespace nuds = "http://nomisma.org/nuds";
 import module namespace request = "http://exist-db.org/xquery/request";
 import module namespace hc = "http://expath.org/ns/http-client";
-declare option exist:serialize "method=xhtml media-type=text/html indent=yes";
+
 
 
 let $collection := replace(request:get-effective-uri(), "^/.*/db/(.*)/.*$", "/db/$1")
 let $objects := collection($collection)/nuds:nuds[nuds:control/nuds:publicationStatus = 'approved']
 
 (: The Graph Store Protocol posts to '/data', not '/query' :)
-let $sparql_endpoint := replace(collection($collection)/config/sparql_endpoint, "query$", "data")
+let $sparql_endpoint := concat(replace(collection($collection)/config/sparql_endpoint, "/query$", ""),"/data")
+(: only http requests can be made :)
+let $sparql_endpoint := replace($sparql_endpoint,"https","http")
 let $uri_space := collection($collection)/config/uri_space
 
 let $posts :=
  for $object in $objects
- let $request := <hc:request method="post" href="{$sparql_endpoint}">
-                   <hc:header name="Cache-Control" value="no-cache"/>
-                   <hc:body media-type="application/rdf+xml">{ doc($uri_space || $object/nuds:control/nuds:recordId || ".rdf") }</hc:body>
-                 </hc:request>
  let $response := hc:send-request(<hc:request method="post" href="{$sparql_endpoint}">
                                     <hc:header name="Cache-Control" value="no-cache"/>
                                     <hc:body media-type="application/rdf+xml">{ doc($uri_space || $object/nuds:control/nuds:recordId || ".rdf") }</hc:body>
@@ -27,24 +25,5 @@ let $posts :=
  return $response[1]
 
 return
- <html>
-  <body>
-   <p>
-    {count($objects)} objects were posted to {$sparql_endpoint}.
-   </p>
-   <dl>
-   
-    <dt>collection</dt>
-    <dd>{$collection}</dd>
-    
-    <dt>object count</dt>
-    <dd>{count($objects)}</dd>
-    
-    <dt>successes</dt>
-    <dd>{count($posts[@status='200'])}</dd>
-    
-    <dt>failures</dt>
-    <dd>{count($posts[not(@status = '200')])}</dd>
-   </dl>
-  </body>
- </html>
+ <result>{$posts}</result>
+

--- a/xforms/xquery/post-to-3store.xq
+++ b/xforms/xquery/post-to-3store.xq
@@ -1,0 +1,50 @@
+xquery version "3.1";
+
+declare namespace exist = "http://exist.sourceforge.net/NS/exist";
+declare namespace nuds = "http://nomisma.org/nuds";
+import module namespace request = "http://exist-db.org/xquery/request";
+import module namespace hc = "http://expath.org/ns/http-client";
+declare option exist:serialize "method=xhtml media-type=text/html indent=yes";
+
+
+let $collection := replace(request:get-effective-uri(), "^/.*/db/(.*)/.*$", "/db/$1")
+let $objects := collection($collection)/nuds:nuds[nuds:control/nuds:publicationStatus = 'approved']
+
+(: The Graph Store Protocol posts to '/data', not '/query' :)
+let $sparql_endpoint := replace(collection($collection)/config/sparql_endpoint, "query$", "data")
+let $uri_space := collection($collection)/config/uri_space
+
+let $posts :=
+ for $object in $objects
+ let $request := <hc:request method="post" href="{$sparql_endpoint}">
+                   <hc:header name="Cache-Control" value="no-cache"/>
+                   <hc:body media-type="application/rdf+xml">{ doc($uri_space || $object/nuds:control/nuds:recordId || ".rdf") }</hc:body>
+                 </hc:request>
+ let $response := hc:send-request(<hc:request method="post" href="{$sparql_endpoint}">
+                                    <hc:header name="Cache-Control" value="no-cache"/>
+                                    <hc:body media-type="application/rdf+xml">{ doc($uri_space || $object/nuds:control/nuds:recordId || ".rdf") }</hc:body>
+                                  </hc:request>) 
+ return $response[1]
+
+return
+ <html>
+  <body>
+   <p>
+    {count($objects)} objects were posted to {$sparql_endpoint}.
+   </p>
+   <dl>
+   
+    <dt>collection</dt>
+    <dd>{$collection}</dd>
+    
+    <dt>object count</dt>
+    <dd>{count($objects)}</dd>
+    
+    <dt>successes</dt>
+    <dd>{count($posts[@status='200'])}</dd>
+    
+    <dt>failures</dt>
+    <dd>{count($posts[not(@status = '200')])}</dd>
+   </dl>
+  </body>
+ </html>


### PR DESCRIPTION
This patch synchronizes the contents of the solr index and the fuseki triple store.

1. Two new actions in the Publication menu on admin.xhtml:

     - Publish all approved objects to 3store
     - Unpublish all objects from 3store

2. Augments the publish/unpublish toggle for items in the list of objects to post/delete triples from the 3store.

The patch implements two new xqueries, post-to-3store.xq and delete-from-3store.xq, which are stored in each collection in eXist.  The XForm in admin.xhtml is modified to use them.